### PR TITLE
Improve tray and Google sign‑in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,25 @@ To stop the server, run the matching stop script or send a POST to `/shutdown/`.
 
 You may also launch `doccropper_tray.py` (or `.pyw`) to manage the server with a system tray icon.
 
+### Tray icon usage
+
+The tray helper works on Windows, macOS and most Linux desktops. If no graphical
+environment is available, run it with the `--no-tray` option to start the server
+without showing an icon:
+
+```bash
+python doccropper_tray.py --no-tray
+```
+If the tray cannot be shown, the script automatically launches the server
+without it.
+
+### Google Sign-In
+
+To enable optional Google authentication, set `google_client_id` in
+`settings.json` or provide it via the environment variable
+`DOCROPPER_GOOGLE_CLIENT_ID`. When configured, a sign-in button will appear in
+the web interface and tokens will be verified by the backend.
+
 ---
 
 ## 🔓 Licensing and PRO Features

--- a/doccropper_tray.py
+++ b/doccropper_tray.py
@@ -96,8 +96,21 @@ def create_image():
 
 
 def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="DocCropper tray helper")
+    parser.add_argument("--no-tray", action="store_true",
+                        help="Run without showing a system tray icon")
+    args = parser.parse_args()
+
     developer = os.environ.get('DOCROPPER_DEVELOPER') == '1' or is_developer()
     logging.info("Tray icon started (developer=%s)", developer)
+
+    if args.no_tray:
+        logging.info("--no-tray specified, launching server directly")
+        start_app()
+        return
+
     menu_items = [
         MenuItem('Start DocCropper', lambda icon, item: start_app()),
         MenuItem('Stop DocCropper', lambda icon, item: stop_app()),
@@ -112,6 +125,8 @@ def main():
         icon.run()
     except Exception as e:
         logging.exception("Tray icon error: %s", e)
+        logging.info("Falling back to running without tray")
+        start_app()
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -92,10 +92,13 @@ def load_settings():
         merged.update(base)
         env_key = os.getenv("DOCROPPER_LICENSE_KEY")
         env_name = os.getenv("DOCROPPER_LICENSE_NAME")
+        google_id = os.getenv("DOCROPPER_GOOGLE_CLIENT_ID")
         if env_key:
             merged["license_key"] = env_key
         if env_name:
             merged["license_name"] = env_name
+        if google_id:
+            merged["google_client_id"] = google_id
         return merged
     except Exception:
         return DEFAULT_SETTINGS.copy()


### PR DESCRIPTION
## Summary
- add fallback to start server if tray icon fails
- allow `google_client_id` via `DOCROPPER_GOOGLE_CLIENT_ID` env var
- add `--no-tray` option to `doccropper_tray.py`
- document tray usage, fallback, and Google sign‑in

## Testing
- `python -m py_compile doccropper_tray.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879148dc4988326b532ceef44916a8a