### PR TITLE
Enhance mobile signing form

### DIFF
--- a/main.py
+++ b/main.py
@@ -964,6 +964,8 @@ async def create_pdf(
                 lines.append(f"Email: {sign_info['email']}")
             if sign_info.get("phone"):
                 lines.append(f"Phone: {sign_info['phone']}")
+            if 'consent' in sign_info:
+                lines.append(f"Consent: {bool(sign_info['consent'])}")
             for idx, sig in enumerate(signatures, 1):
                 lines.append(
                     f"Signature {idx}: page {sig.get('page', 0)+1} x={sig.get('x',0):.2f} y={sig.get('y',0):.2f} scale={sig.get('scale',1)}"

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import time
 import uuid
+from datetime import datetime
 
 import cv2
 import numpy as np
@@ -740,7 +741,8 @@ async def create_pdf(
     scale_percent: int = Body(100),
     color_mode: str = Body("color"),
     signature_image: str | None = Body(None),
-    signatures: list[dict] = Body(default_factory=list)
+    signatures: list[dict] = Body(default_factory=list),
+    sign_info: dict | None = Body(default_factory=dict)
 ):
     try:
         settings = load_settings()
@@ -947,6 +949,29 @@ async def create_pdf(
                         sy = page_h - margin - footer_h - h
                     page.paste(stamp, (sx, sy), stamp)
             pages.append(page)
+
+        if sign_info:
+            log_page = Image.new("RGB", (page_w, page_h), "white")
+            draw = ImageDraw.Draw(log_page)
+            try:
+                log_font = ImageFont.truetype("DejaVuSans.ttf", 40)
+            except Exception:
+                log_font = ImageFont.load_default()
+            y = 100
+            ts = sign_info.get("timestamp") or datetime.utcnow().isoformat()
+            lines = [f"Signed on: {ts}"]
+            if sign_info.get("email"):
+                lines.append(f"Email: {sign_info['email']}")
+            if sign_info.get("phone"):
+                lines.append(f"Phone: {sign_info['phone']}")
+            for idx, sig in enumerate(signatures, 1):
+                lines.append(
+                    f"Signature {idx}: page {sig.get('page', 0)+1} x={sig.get('x',0):.2f} y={sig.get('y',0):.2f} scale={sig.get('scale',1)}"
+                )
+            for line in lines:
+                draw.text((100, y), line, fill="black", font=log_font)
+                y += log_font.getsize(line)[1] + 20
+            pages.append(log_page)
 
         pdf_bytes_io = io.BytesIO()
         pages[0].save(pdf_bytes_io, format="PDF", save_all=True, append_images=pages[1:])

--- a/main.py
+++ b/main.py
@@ -972,7 +972,15 @@ async def create_pdf(
                 )
             for line in lines:
                 draw.text((100, y), line, fill="black", font=log_font)
-                y += log_font.getsize(line)[1] + 20
+                if hasattr(draw, "textbbox"):
+                    bbox = draw.textbbox((100, y), line, font=log_font)
+                    line_h = bbox[3] - bbox[1]
+                elif hasattr(log_font, "getbbox"):
+                    bbox = log_font.getbbox(line)
+                    line_h = bbox[3] - bbox[1]
+                else:
+                    line_h = log_font.size
+                y += line_h + 20
             pages.append(log_page)
 
         pdf_bytes_io = io.BytesIO()

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -166,9 +166,15 @@ Il dominio doccropper.iltuoconsulenteit.it è utilizzato esclusivamente a scopo 
                     }
                 }
             }catch{}
-            images.forEach((img,idx)=>{const opt=document.createElement('option');opt.value=idx;opt.textContent=(idx+1);pageSelect.appendChild(opt);});
+            pageSelect.innerHTML='';
+            images.forEach((img,idx)=>{
+                const opt=document.createElement('option');
+                opt.value=idx;
+                opt.textContent=(idx+1);
+                pageSelect.appendChild(opt);
+            });
             pageSelect.value={page};
-            docImg.src=images[pageSelect.value];
+            docImg.src=images[pageSelect.value]||'';
             drawSpots();
         }
         loadPages();
@@ -200,10 +206,10 @@ Il dominio doccropper.iltuoconsulenteit.it è utilizzato esclusivamente a scopo 
             const r=e.target.getBoundingClientRect();
             openPad((e.clientX-r.left)/r.width,(e.clientY-r.top)/r.height);
         };
-        docImg.addEventListener('touchend',e=>{
+        docImg.addEventListener('touchstart',e=>{
             if(finished) return;
             const now=Date.now();
-            const t=e.changedTouches[0];
+            const t=e.touches[0];
             const r=e.target.getBoundingClientRect();
             const x=(t.clientX-r.left)/r.width;
             const y=(t.clientY-r.top)/r.height;

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -1,7 +1,8 @@
 from fastapi import Request, Body
-from fastapi.responses import HTMLResponse, JSONResponse
-import uuid, qrcode, io, base64, os, json
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+import uuid, qrcode, io, base64, os, json, hashlib, logging
 from datetime import datetime
+import fitz
 
 __all__ = ['register']
 
@@ -20,6 +21,7 @@ def register(app, utils):
         page = int(data.get('page', 0))
         images = data.get('images') if isinstance(data.get('images'), list) else None
         points = data.get('points') if isinstance(data.get('points'), dict) else {}
+        name = data.get('name', '')
         email = data.get('email', '')
         phone = data.get('phone', '')
         if images:
@@ -38,6 +40,7 @@ def register(app, utils):
             'points': points,
             'signed': False,
             'signatures': [],
+            'name': name,
             'email': email,
             'phone': phone,
         }
@@ -81,6 +84,7 @@ def register(app, utils):
         page_index = int(info.get('page', 0))
         email = info.get('email', '')
         phone = info.get('phone', '')
+        name = info.get('name', '')
         html = """
         <html><head>
         <meta name='viewport' content='width=device-width,initial-scale=1.0'>
@@ -96,6 +100,7 @@ def register(app, utils):
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
         <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
         <label style='display:block;margin-top:5px;'><input type='checkbox' id='consentFlag'> Consento il trattamento dei dati</label>
+        <input id='nameInput' type='text' placeholder='Nome' value='{name}' style='width:90%;max-width:300px;margin-top:5px;'>
         <input id='emailInput' type='email' placeholder='Email' value='{email}' style='width:90%;max-width:300px;margin-top:5px;'>
         <input id='phoneInput' type='tel' placeholder='Cellulare' value='{phone}' style='width:90%;max-width:300px;margin-top:5px;'>
         <p id='finishMsg' style='display:none;color:green;font-weight:bold'></p>
@@ -127,6 +132,7 @@ def register(app, utils):
         const submitBtn=document.getElementById('submit');
         const clearBtn=document.getElementById('clear');
         const finishBtn=document.getElementById('finish');
+        const nameInput=document.getElementById('nameInput');
         const emailInput=document.getElementById('emailInput');
         const phoneInput=document.getElementById('phoneInput');
         const consentFlag=document.getElementById('consentFlag');
@@ -233,7 +239,7 @@ def register(app, utils):
             if(!pad.isEmpty()) await submitCurrent();
             finishMsg.textContent='Sending signatures...';
             finishMsg.style.display='block';
-            await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
+            await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:nameInput.value||'',email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
             finishMsg.textContent='Signatures sent. Waiting for PDF...';
             finished=true;
             finishBtn.disabled=true;
@@ -244,7 +250,7 @@ def register(app, utils):
         };
         </script>
         </body></html>
-        """.replace('{token}', token).replace('{img}', img_b64).replace('{images_json}', json.dumps(images)).replace('{spots_json}', json.dumps(points)).replace('{page}', str(page_index)).replace('{email}', email).replace('{phone}', phone)
+        """.replace('{token}', token).replace('{img}', img_b64).replace('{images_json}', json.dumps(images)).replace('{spots_json}', json.dumps(points)).replace('{page}', str(page_index)).replace('{email}', email).replace('{phone}', phone).replace('{name}', name)
         return HTMLResponse(content=html)
 
     @app.get('/sign-pages/{token}')
@@ -303,6 +309,7 @@ def register(app, utils):
         with open(info_path, 'r') as fh:
             info = json.load(fh)
         info['signed'] = True
+        info['name'] = data.get('name','')
         info['email'] = data.get('email','')
         info['phone'] = data.get('phone','')
         info['consent'] = bool(data.get('consent', False))
@@ -327,10 +334,38 @@ def register(app, utils):
             page = sig.get('page', info.get('page', 0))
             pages.setdefault(page, []).append({'image': 'data:image/png;base64,' + b64, 'x': sig['x'], 'y': sig['y'], 'scale': sig.get('scale', 1.0)})
         result = {'signatures': pages}
-        for key in ('email', 'phone', 'timestamp', 'consent'):
+        for key in ('name', 'email', 'phone', 'timestamp', 'consent'):
             if key in info:
                 result[key] = info[key]
         return result
+
+    def send_mail(to_addr: str, subject: str, body: str, attachment: str | None = None):
+        settings = load_settings()
+        server = os.getenv('SMTP_SERVER') or settings.get('smtp_server')
+        user = os.getenv('SMTP_USER') or settings.get('smtp_user')
+        password = os.getenv('SMTP_PASS') or settings.get('smtp_pass')
+        port = int(os.getenv('SMTP_PORT') or settings.get('smtp_port', 587))
+        sender = os.getenv('SMTP_FROM') or settings.get('smtp_from', user)
+        if not (server and user and password and to_addr):
+            return
+        import smtplib
+        from email.message import EmailMessage
+        msg = EmailMessage()
+        msg['Subject'] = subject
+        msg['From'] = sender
+        msg['To'] = to_addr
+        msg.set_content(body)
+        if attachment:
+            with open(attachment, 'rb') as fh:
+                data = fh.read()
+            msg.add_attachment(data, maintype='application', subtype='pdf', filename=os.path.basename(attachment))
+        try:
+            with smtplib.SMTP(server, port) as s:
+                s.starttls()
+                s.login(user, password)
+                s.send_message(msg)
+        except Exception:
+            logging.exception('Email send failed')
 
     @app.post('/store-signed-pdf/{token}')
     async def store_signed_pdf(request: Request, token: str, data: dict = Body(...)):
@@ -348,14 +383,46 @@ def register(app, utils):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
+        hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
+        ts = info.get('timestamp') or datetime.utcnow().isoformat()
+        name = info.get('name', '')
+        ip = request.client.host or ''
+        email = info.get('email', '')
+        legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS (UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
+        try:
+            doc = fitz.open(stream=pdf_bytes, filetype='pdf')
+            page = doc[-1]
+            rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)
+            page.insert_textbox(rect, legal, fontsize=8, align=1)
+            pdf_bytes = doc.tobytes()
+            doc.close()
+        except Exception:
+            logging.exception('Failed to append legal text')
         pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
         with open(pdf_path, 'wb') as fh:
             fh.write(pdf_bytes)
         url = request.url_for('download_signed_pdf', token=token)
         info['pdf_file'] = pdf_path
         info['pdf_url'] = str(url)
+        info['pdf_hash'] = hash_hex
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
+        log_entry = {
+            'token': token,
+            'pdf_file': os.path.basename(pdf_path),
+            'hash': hash_hex,
+            'timestamp': ts,
+            'ip': ip,
+            'user_agent': request.headers.get('user-agent', ''),
+            'email': email,
+            'name': name,
+            'consent': info.get('consent', False)
+        }
+        os.makedirs('log_firme', exist_ok=True)
+        with open(os.path.join('log_firme', f'firma_{token}.json'), 'w') as fh:
+            json.dump(log_entry, fh, indent=2)
+        if email:
+            send_mail(email, 'Documento firmato', f'SHA256: {hash_hex}', pdf_path)
         return {'status': 'ok', 'url': str(url)}
 
     @app.get('/signed-pdf/{token}')
@@ -375,7 +442,7 @@ def register(app, utils):
                 return JSONResponse(status_code=202, content={'message': 'Pending'})
             url = request.url_for('download_signed_pdf', token=token)
             result['url'] = str(url)
-        for key in ('email', 'phone'):
+        for key in ('name', 'email', 'phone'):
             if key in info:
                 result[key] = info[key]
         return result

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -98,7 +98,19 @@ def register(app, utils):
         <script src='https://cdn.jsdelivr.net/npm/signature_pad@4.1.5/dist/signature_pad.umd.min.js'></script>
         </head><body>
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
-        <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
+        <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold;text-align:left;'>⚠️ Avvertenza legale – Firma elettronica semplice (FES)<br>
+Il sistema di firma Mobile Sign, integrato in DocCropper, consente la raccolta di firme elettroniche grafiche in modalità conforme ai requisiti della firma elettronica semplice (FES), come definita dal Regolamento UE 910/2014 eIDAS e dal Codice dell'Amministrazione Digitale (CAD).<br><br>
+La firma avviene tramite consenso esplicito e tracciabile da parte del firmatario, ed è tecnicamente associata al documento firmato.<br><br>
+Tuttavia, DocCropper e il sito doccropper.iltuoconsulenteit.it:<br>
+- non sono prestatori di servizi fiduciari qualificati (QTSP) ai sensi della normativa europea;<br>
+- non garantiscono la validità legale delle firme raccolte in tutti i contesti giuridici o amministrativi;<br>
+- non conservano copie dei documenti né dei log firma se non con integrazione personalizzata;<br>
+- non si assumono alcuna responsabilità per usi impropri, illeciti o non consentiti dalla legge del sistema Mobile Sign.<br><br>
+Il dominio doccropper.iltuoconsulenteit.it è utilizzato esclusivamente a scopo dimostrativo e di test: non costituisce un servizio di firma elettronica centralizzato, certificato o destinato a produzione.<br><br>
+È responsabilità esclusiva dell’utente o del richiedente garantire che l’uso del sistema avvenga:<br>
+- nel rispetto della normativa applicabile;<br>
+- con adeguata identificazione e informazione del firmatario;<br>
+- in contesti compatibili con l’uso della firma elettronica semplice.</p>
         <label style='display:block;margin-top:5px;'><input type='checkbox' id='consentFlag'> Consento il trattamento dei dati</label>
         <input id='nameInput' type='text' placeholder='Nome' value='{name}' style='width:90%;max-width:300px;margin-top:5px;'>
         <input id='emailInput' type='email' placeholder='Email' value='{email}' style='width:90%;max-width:300px;margin-top:5px;'>

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -91,7 +91,7 @@ def register(app, utils):
         <style>
         body{ text-align:center;font-family:sans-serif; }
         #container{ position:relative; display:inline-block; }
-        #docImg{ max-width:100%; height:auto; display:block; }
+        #docImg{ max-width:100%; height:auto; display:block; touch-action: manipulation; }
         #overlay{ position:absolute; left:0; top:0; pointer-events:none; }
         #pad{ border:1px solid #000; display:none; margin-top:10px; width:100%; height:200px }
         </style>

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -194,11 +194,12 @@ def register(app, utils):
         const pdfLink=document.getElementById('pdfLink');
         async function pollPdf(){
             try{
-                const r=await fetch('/signed-pdf/{token}');
+                const r=await fetch('/signed-pdf/{token}',{cache:'no-store'});
                 if(r.status===200){
                     const d=await r.json();
                     if(d.url){
                         pdfLink.href=d.url;
+                        pdfLink.textContent='Download PDF';
                         pdfLink.style.display='block';
                         finishMsg.textContent='Signatures sent. Download your PDF:';
                         return;
@@ -330,10 +331,11 @@ def register(app, utils):
         pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
         with open(pdf_path, 'wb') as fh:
             fh.write(pdf_bytes)
+        url = request.url_for('download_signed_pdf', token=token)
         info['pdf_file'] = pdf_path
+        info['pdf_url'] = str(url)
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
-        url = request.url_for('download_signed_pdf', token=token)
         return {'status': 'ok', 'url': str(url)}
 
     @app.get('/signed-pdf/{token}')
@@ -343,6 +345,9 @@ def register(app, utils):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
+        pdf_url = info.get('pdf_url')
+        if pdf_url:
+            return {'url': pdf_url}
         pdf_path = info.get('pdf_file')
         if not pdf_path or not os.path.exists(pdf_path):
             return JSONResponse(status_code=202, content={'message': 'Pending'})

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -1,6 +1,7 @@
 from fastapi import Request, Body
 from fastapi.responses import HTMLResponse, JSONResponse
 import uuid, qrcode, io, base64, os, json
+from datetime import datetime
 
 __all__ = ['register']
 
@@ -260,6 +261,7 @@ def register(app, utils):
         info['email'] = data.get('email','')
         info['phone'] = data.get('phone','')
         info['consent'] = bool(data.get('consent', False))
+        info['timestamp'] = datetime.utcnow().isoformat()
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
         return {'status': 'ok'}
@@ -279,4 +281,8 @@ def register(app, utils):
                 b64 = base64.b64encode(fh.read()).decode()
             page = sig.get('page', info.get('page', 0))
             pages.setdefault(page, []).append({'image': 'data:image/png;base64,' + b64, 'x': sig['x'], 'y': sig['y'], 'scale': sig.get('scale', 1.0)})
-        return {'signatures': pages}
+        result = {'signatures': pages}
+        for key in ('email', 'phone', 'timestamp', 'consent'):
+            if key in info:
+                result[key] = info[key]
+        return result

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -88,6 +88,9 @@ def register(app, utils):
         </head><body>
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
         <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
+        <label style='display:block;margin-top:5px;'><input type='checkbox' id='consentFlag'> Consento il trattamento dei dati</label>
+        <input id='emailInput' type='email' placeholder='Email' style='width:90%;max-width:300px;margin-top:5px;'>
+        <input id='phoneInput' type='tel' placeholder='Cellulare' style='width:90%;max-width:300px;margin-top:5px;'>
         <p id='finishMsg' style='display:none;color:green;font-weight:bold'></p>
         <p>Tap the document then draw your signature</p>
         <select id='pageSelect' style='margin-top:10px'></select>
@@ -114,6 +117,9 @@ def register(app, utils):
         const submitBtn=document.getElementById('submit');
         const clearBtn=document.getElementById('clear');
         const finishBtn=document.getElementById('finish');
+        const emailInput=document.getElementById('emailInput');
+        const phoneInput=document.getElementById('phoneInput');
+        const consentFlag=document.getElementById('consentFlag');
         const scaleInput=document.getElementById('scaleRange');
         let scale=1;
         if(scaleInput){
@@ -182,7 +188,7 @@ def register(app, utils):
             if(!pad.isEmpty()) await submitCurrent();
             finishMsg.textContent='Sending signatures...';
             finishMsg.style.display='block';
-            await fetch('/finish-signing/{token}',{method:'POST'});
+            await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
             finishMsg.textContent='Signatures sent. You may close this page.';
             finished=true;
             finishBtn.disabled=true;
@@ -244,13 +250,16 @@ def register(app, utils):
         return {'status': 'ok'}
 
     @app.post('/finish-signing/{token}')
-    async def finish_signing(token: str):
+    async def finish_signing(token: str, data: dict = Body(default_factory=dict)):
         info_path = os.path.join(signatures_dir, f'{token}.json')
         if not os.path.exists(info_path):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
         info['signed'] = True
+        info['email'] = data.get('email','')
+        info['phone'] = data.get('phone','')
+        info['consent'] = bool(data.get('consent', False))
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
         return {'status': 'ok'}

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -107,6 +107,7 @@ def register(app, utils):
         <a id='pdfLink' style='display:none;margin-top:5px;' download='signed.pdf'>Download PDF</a>
         <button id='waPdfBtn' style='display:none;margin-left:10px;'>WhatsApp</button>
         <button id='emailPdfBtn' style='display:none;margin-left:10px;'>Email</button>
+        <pre id='signInfo' style='display:none;font-size:small;text-align:left;margin-top:10px;'></pre>
         <p>Tap the document then draw your signature</p>
         <select id='pageSelect' style='margin-top:10px'></select>
         <div id='container'>
@@ -202,6 +203,7 @@ def register(app, utils):
         const pdfLink=document.getElementById('pdfLink');
         const waPdfBtn=document.getElementById('waPdfBtn');
         const emailPdfBtn=document.getElementById('emailPdfBtn');
+        const signInfo=document.getElementById('signInfo');
         async function pollPdf(){
             try{
                 const r=await fetch('/signed-pdf/{token}',{cache:'no-store'});
@@ -212,6 +214,16 @@ def register(app, utils):
                         pdfLink.textContent='Download PDF';
                         pdfLink.style.display='block';
                         finishMsg.textContent='Signatures sent. Download your PDF:';
+                        if(signInfo){
+                            const lines=[];
+                            if(d.name) lines.push('Nome firmatario: '+d.name);
+                            if(d.email) lines.push('Email: '+d.email);
+                            if(d.timestamp) lines.push('Data/ora: '+d.timestamp);
+                            if(d.ip) lines.push('IP: '+d.ip);
+                            if(d.pdf_hash) lines.push('Hash: '+d.pdf_hash);
+                            signInfo.textContent=lines.join('\n');
+                            signInfo.style.display='block';
+                        }
                         if(waPdfBtn){
                             waPdfBtn.onclick=()=>{
                                 const p=(d.phone||'').replace(/[^0-9]/g,'');
@@ -394,6 +406,20 @@ def register(app, utils):
             page = doc[-1]
             rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)
             page.insert_textbox(rect, legal, fontsize=8, align=1)
+            info_lines = [
+                f"Nome firmatario: {name}",
+                f"Email: {email}",
+                f"Data/ora: {ts}",
+                f"IP: {ip}",
+                f"Token firma: {token}",
+                f"Hash documento: {hash_hex}",
+            ]
+            info_page = doc.new_page(-1)
+            info_page.insert_textbox(
+                fitz.Rect(50, 50, info_page.rect.width - 50, info_page.rect.height - 50),
+                "\n".join(info_lines),
+                fontsize=12,
+            )
             pdf_bytes = doc.tobytes()
             doc.close()
         except Exception:
@@ -405,6 +431,8 @@ def register(app, utils):
         info['pdf_file'] = pdf_path
         info['pdf_url'] = str(url)
         info['pdf_hash'] = hash_hex
+        info['ip'] = ip
+        info['timestamp'] = ts
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
         log_entry = {
@@ -423,7 +451,7 @@ def register(app, utils):
             json.dump(log_entry, fh, indent=2)
         if email:
             send_mail(email, 'Documento firmato', f'SHA256: {hash_hex}', pdf_path)
-        return {'status': 'ok', 'url': str(url)}
+        return {'status': 'ok', 'url': str(url), 'pdf_hash': hash_hex, 'name': name, 'email': email, 'timestamp': ts, 'ip': ip}
 
     @app.get('/signed-pdf/{token}')
     async def signed_pdf(request: Request, token: str):
@@ -442,7 +470,7 @@ def register(app, utils):
                 return JSONResponse(status_code=202, content={'message': 'Pending'})
             url = request.url_for('download_signed_pdf', token=token)
             result['url'] = str(url)
-        for key in ('name', 'email', 'phone'):
+        for key in ('name', 'email', 'phone', 'timestamp', 'ip', 'pdf_hash'):
             if key in info:
                 result[key] = info[key]
         return result

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -100,6 +100,8 @@ def register(app, utils):
         <input id='phoneInput' type='tel' placeholder='Cellulare' value='{phone}' style='width:90%;max-width:300px;margin-top:5px;'>
         <p id='finishMsg' style='display:none;color:green;font-weight:bold'></p>
         <a id='pdfLink' style='display:none;margin-top:5px;' download='signed.pdf'>Download PDF</a>
+        <button id='waPdfBtn' style='display:none;margin-left:10px;'>WhatsApp</button>
+        <button id='emailPdfBtn' style='display:none;margin-left:10px;'>Email</button>
         <p>Tap the document then draw your signature</p>
         <select id='pageSelect' style='margin-top:10px'></select>
         <div id='container'>
@@ -192,6 +194,8 @@ def register(app, utils):
         submitBtn.onclick=submitCurrent;
         const finishMsg=document.getElementById('finishMsg');
         const pdfLink=document.getElementById('pdfLink');
+        const waPdfBtn=document.getElementById('waPdfBtn');
+        const emailPdfBtn=document.getElementById('emailPdfBtn');
         async function pollPdf(){
             try{
                 const r=await fetch('/signed-pdf/{token}',{cache:'no-store'});
@@ -202,6 +206,22 @@ def register(app, utils):
                         pdfLink.textContent='Download PDF';
                         pdfLink.style.display='block';
                         finishMsg.textContent='Signatures sent. Download your PDF:';
+                        if(waPdfBtn){
+                            waPdfBtn.onclick=()=>{
+                                const p=(d.phone||'').replace(/[^0-9]/g,'');
+                                const u=p?`https://wa.me/${p}?text=${encodeURIComponent(d.url)}`:`https://wa.me/?text=${encodeURIComponent(d.url)}`;
+                                window.open(u,'_blank');
+                            };
+                            waPdfBtn.style.display='inline';
+                        }
+                        if(emailPdfBtn){
+                            emailPdfBtn.onclick=()=>{
+                                const m=d.email?encodeURIComponent(d.email):'';
+                                const mailto=`mailto:${m}?body=${encodeURIComponent(d.url)}`;
+                                window.open(mailto,'_blank');
+                            };
+                            emailPdfBtn.style.display='inline';
+                        }
                         return;
                     }
                 }
@@ -346,13 +366,19 @@ def register(app, utils):
         with open(info_path, 'r') as fh:
             info = json.load(fh)
         pdf_url = info.get('pdf_url')
+        result = {}
         if pdf_url:
-            return {'url': pdf_url}
-        pdf_path = info.get('pdf_file')
-        if not pdf_path or not os.path.exists(pdf_path):
-            return JSONResponse(status_code=202, content={'message': 'Pending'})
-        url = request.url_for('download_signed_pdf', token=token)
-        return {'url': str(url)}
+            result['url'] = pdf_url
+        else:
+            pdf_path = info.get('pdf_file')
+            if not pdf_path or not os.path.exists(pdf_path):
+                return JSONResponse(status_code=202, content={'message': 'Pending'})
+            url = request.url_for('download_signed_pdf', token=token)
+            result['url'] = str(url)
+        for key in ('email', 'phone'):
+            if key in info:
+                result[key] = info[key]
+        return result
 
     @app.get('/download-signed/{token}.pdf', name='download_signed_pdf')
     async def download_signed_pdf(token: str):

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -20,6 +20,8 @@ def register(app, utils):
         page = int(data.get('page', 0))
         images = data.get('images') if isinstance(data.get('images'), list) else None
         points = data.get('points') if isinstance(data.get('points'), dict) else {}
+        email = data.get('email', '')
+        phone = data.get('phone', '')
         if images:
             if len(images) == 0:
                 return JSONResponse(status_code=400, content={'message': 'No image supplied'})
@@ -36,6 +38,8 @@ def register(app, utils):
             'points': points,
             'signed': False,
             'signatures': [],
+            'email': email,
+            'phone': phone,
         }
         os.makedirs(signatures_dir, exist_ok=True)
         with open(os.path.join(signatures_dir, f'{token}.json'), 'w') as fh:
@@ -75,6 +79,8 @@ def register(app, utils):
         images = info.get('images') or [img_b64]
         points = info.get('points') or {}
         page_index = int(info.get('page', 0))
+        email = info.get('email', '')
+        phone = info.get('phone', '')
         html = """
         <html><head>
         <meta name='viewport' content='width=device-width,initial-scale=1.0'>
@@ -90,9 +96,10 @@ def register(app, utils):
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
         <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
         <label style='display:block;margin-top:5px;'><input type='checkbox' id='consentFlag'> Consento il trattamento dei dati</label>
-        <input id='emailInput' type='email' placeholder='Email' style='width:90%;max-width:300px;margin-top:5px;'>
-        <input id='phoneInput' type='tel' placeholder='Cellulare' style='width:90%;max-width:300px;margin-top:5px;'>
+        <input id='emailInput' type='email' placeholder='Email' value='{email}' style='width:90%;max-width:300px;margin-top:5px;'>
+        <input id='phoneInput' type='tel' placeholder='Cellulare' value='{phone}' style='width:90%;max-width:300px;margin-top:5px;'>
         <p id='finishMsg' style='display:none;color:green;font-weight:bold'></p>
+        <a id='pdfLink' style='display:none;margin-top:5px;' download='signed.pdf'>Download PDF</a>
         <p>Tap the document then draw your signature</p>
         <select id='pageSelect' style='margin-top:10px'></select>
         <div id='container'>
@@ -184,22 +191,39 @@ def register(app, utils):
         }
         submitBtn.onclick=submitCurrent;
         const finishMsg=document.getElementById('finishMsg');
+        const pdfLink=document.getElementById('pdfLink');
+        async function pollPdf(){
+            try{
+                const r=await fetch('/signed-pdf/{token}');
+                if(r.status===200){
+                    const d=await r.json();
+                    if(d.pdf){
+                        pdfLink.href=d.pdf;
+                        pdfLink.style.display='block';
+                        finishMsg.textContent='Signatures sent. Download your PDF:';
+                        return;
+                    }
+                }
+            }catch{}
+            setTimeout(pollPdf,3000);
+        }
         finishBtn.onclick=async()=>{
             if(finished) return;
             if(!pad.isEmpty()) await submitCurrent();
             finishMsg.textContent='Sending signatures...';
             finishMsg.style.display='block';
             await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
-            finishMsg.textContent='Signatures sent. You may close this page.';
+            finishMsg.textContent='Signatures sent. Waiting for PDF...';
             finished=true;
             finishBtn.disabled=true;
             submitBtn.disabled=true;
             clearBtn.disabled=true;
             docImg.onclick=null;
+            pollPdf();
         };
         </script>
         </body></html>
-        """.replace('{token}', token).replace('{img}', img_b64).replace('{images_json}', json.dumps(images)).replace('{spots_json}', json.dumps(points)).replace('{page}', str(page_index))
+        """.replace('{token}', token).replace('{img}', img_b64).replace('{images_json}', json.dumps(images)).replace('{spots_json}', json.dumps(points)).replace('{page}', str(page_index)).replace('{email}', email).replace('{phone}', phone)
         return HTMLResponse(content=html)
 
     @app.get('/sign-pages/{token}')
@@ -286,3 +310,30 @@ def register(app, utils):
             if key in info:
                 result[key] = info[key]
         return result
+
+    @app.post('/store-signed-pdf/{token}')
+    async def store_signed_pdf(token: str, data: dict = Body(...)):
+        pdf_b64 = data.get('pdf')
+        if not pdf_b64:
+            return JSONResponse(status_code=400, content={'message': 'No PDF'})
+        info_path = os.path.join(signatures_dir, f'{token}.json')
+        if not os.path.exists(info_path):
+            return JSONResponse(status_code=404, content={'message': 'Not found'})
+        with open(info_path, 'r') as fh:
+            info = json.load(fh)
+        info['pdf'] = pdf_b64
+        with open(info_path, 'w') as fh:
+            json.dump(info, fh)
+        return {'status': 'ok'}
+
+    @app.get('/signed-pdf/{token}')
+    async def signed_pdf(token: str):
+        info_path = os.path.join(signatures_dir, f'{token}.json')
+        if not os.path.exists(info_path):
+            return JSONResponse(status_code=404, content={'message': 'Not found'})
+        with open(info_path, 'r') as fh:
+            info = json.load(fh)
+        pdf_b64 = info.get('pdf')
+        if not pdf_b64:
+            return JSONResponse(status_code=202, content={'message': 'Pending'})
+        return {'pdf': pdf_b64}

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -189,7 +189,32 @@ Il dominio doccropper.iltuoconsulenteit.it è utilizzato esclusivamente a scopo 
             list.forEach(pt=>{const x=pt.x*overlay.width;const y=pt.y*overlay.height;ctx.beginPath();ctx.moveTo(x-10,y);ctx.lineTo(x+10,y);ctx.moveTo(x,y-10);ctx.lineTo(x,y+10);ctx.stroke();});
         }
         pageSelect.onchange=()=>{ docImg.src=images[pageSelect.value]; drawSpots(); pos=null; };
-        docImg.onclick=e=>{ if(finished) return; const r=e.target.getBoundingClientRect(); pos={x:(e.clientX-r.left)/r.width,y:(e.clientY-r.top)/r.height}; padEl.style.display='block'; controls.style.display='block'; };
+        let lastTap=0;
+        function openPad(x,y){
+            pos={x,y};
+            padEl.style.display='block';
+            controls.style.display='block';
+        }
+        docImg.ondblclick=e=>{
+            if(finished) return;
+            const r=e.target.getBoundingClientRect();
+            openPad((e.clientX-r.left)/r.width,(e.clientY-r.top)/r.height);
+        };
+        docImg.addEventListener('touchend',e=>{
+            if(finished) return;
+            const now=Date.now();
+            const t=e.changedTouches[0];
+            const r=e.target.getBoundingClientRect();
+            const x=(t.clientX-r.left)/r.width;
+            const y=(t.clientY-r.top)/r.height;
+            if(now-lastTap<300){
+                e.preventDefault();
+                openPad(x,y);
+            }else{
+                pos={x,y};
+            }
+            lastTap=now;
+        });
         clearBtn.onclick=()=>pad.clear();
         async function submitCurrent(){
             if(!pos||pad.isEmpty())return false;

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -197,8 +197,8 @@ def register(app, utils):
                 const r=await fetch('/signed-pdf/{token}');
                 if(r.status===200){
                     const d=await r.json();
-                    if(d.pdf){
-                        pdfLink.href=d.pdf;
+                    if(d.url){
+                        pdfLink.href=d.url;
                         pdfLink.style.display='block';
                         finishMsg.textContent='Signatures sent. Download your PDF:';
                         return;
@@ -312,28 +312,46 @@ def register(app, utils):
         return result
 
     @app.post('/store-signed-pdf/{token}')
-    async def store_signed_pdf(token: str, data: dict = Body(...)):
+    async def store_signed_pdf(request: Request, token: str, data: dict = Body(...)):
         pdf_b64 = data.get('pdf')
         if not pdf_b64:
             return JSONResponse(status_code=400, content={'message': 'No PDF'})
+        if pdf_b64.startswith('data:'):
+            pdf_b64 = pdf_b64.split(',', 1)[1]
+        try:
+            pdf_bytes = base64.b64decode(pdf_b64)
+        except Exception:
+            return JSONResponse(status_code=400, content={'message': 'Invalid PDF'})
         info_path = os.path.join(signatures_dir, f'{token}.json')
         if not os.path.exists(info_path):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
-        info['pdf'] = pdf_b64
+        pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
+        with open(pdf_path, 'wb') as fh:
+            fh.write(pdf_bytes)
+        info['pdf_file'] = pdf_path
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
-        return {'status': 'ok'}
+        url = request.url_for('download_signed_pdf', token=token)
+        return {'status': 'ok', 'url': str(url)}
 
     @app.get('/signed-pdf/{token}')
-    async def signed_pdf(token: str):
+    async def signed_pdf(request: Request, token: str):
         info_path = os.path.join(signatures_dir, f'{token}.json')
         if not os.path.exists(info_path):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
-        pdf_b64 = info.get('pdf')
-        if not pdf_b64:
+        pdf_path = info.get('pdf_file')
+        if not pdf_path or not os.path.exists(pdf_path):
             return JSONResponse(status_code=202, content={'message': 'Pending'})
-        return {'pdf': pdf_b64}
+        url = request.url_for('download_signed_pdf', token=token)
+        return {'url': str(url)}
+
+    @app.get('/download-signed/{token}.pdf', name='download_signed_pdf')
+    async def download_signed_pdf(token: str):
+        pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
+        if not os.path.exists(pdf_path):
+            return JSONResponse(status_code=404, content={'message': 'Not found'})
+        return FileResponse(pdf_path, media_type='application/pdf', filename=f'signed_{token}.pdf', headers={"Cache-Control": "no-cache"})

--- a/static/app.js
+++ b/static/app.js
@@ -1780,6 +1780,7 @@ cameraSelect.addEventListener('change', () => {
     }
 });
 let lastTap = 0;
+let lastSigTap = 0;
 imageElement.addEventListener('dblclick', autoDetectCorners);
 imageElement.addEventListener('touchend', (e) => {
     const now = Date.now();
@@ -1974,10 +1975,10 @@ if (signaturePreview) {
         if (draggingSig) updateSigPosition(e);
     });
     document.addEventListener('mouseup', () => { draggingSig = false; });
-    signaturePreview.addEventListener('dblclick', (e) => {
+    const handleSigPos = (clientX, clientY) => {
         const rect = signaturePreview.getBoundingClientRect();
-        const x = (e.clientX - rect.left) / signaturePreview.width;
-        const y = (e.clientY - rect.top) / signaturePreview.height;
+        const x = (clientX - rect.left) / signaturePreview.width;
+        const y = (clientY - rect.top) / signaturePreview.height;
         if (signatureImg) {
             signaturePosition.x = x;
             signaturePosition.y = y;
@@ -1986,6 +1987,18 @@ if (signaturePreview) {
             pendingSigPos = { x, y };
             signatureModal.style.display = 'block';
         }
+    };
+    signaturePreview.addEventListener('dblclick', (e) => {
+        handleSigPos(e.clientX, e.clientY);
+    });
+    signaturePreview.addEventListener('touchend', (e) => {
+        const now = Date.now();
+        if (now - lastSigTap < 300) {
+            e.preventDefault();
+            const touch = e.changedTouches[0];
+            handleSigPos(touch.clientX, touch.clientY);
+        }
+        lastSigTap = now;
     });
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -43,6 +43,7 @@ const processedImageElement = document.getElementById('processedImage');
 const processedGallery = document.getElementById('processedGallery');
 const statusMessageElement = document.getElementById('statusMessage');
 const signedPdfLink = document.getElementById('signedPdfLink');
+const signedInfo = document.getElementById('signedInfo');
 const reorderHint = document.getElementById('reorderHint');
 const imageModal = document.getElementById('imageModal');
 const modalImage = document.getElementById('modalImage');
@@ -1657,8 +1658,9 @@ function generatePdf() {
     const scale_mode = scaleMode.value || 'fit';
     const scale_percent = parseInt(scalePercent.value || '100');
     const payload = { images: processedImages, layout, orientation, arrangement, scale_mode, scale_percent, color_mode: globalColorMode, signature_image: signatureImageData, signatures };
-    if (window.lastSignEmail || window.lastSignPhone || window.lastSignName) {
+    if (window.lastSignEmail || window.lastSignPhone || window.lastSignName || window.lastSignToken) {
         payload.sign_info = { email: window.lastSignEmail, phone: window.lastSignPhone, name: window.lastSignName };
+        if (window.lastSignToken) payload.sign_info.token = window.lastSignToken;
     }
     fetch('/create-pdf/', {
         method: 'POST',
@@ -1697,6 +1699,16 @@ function generatePdf() {
                             signedPdfLink.href = d.url;
                             signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
                             signedPdfLink.style.display = 'inline';
+                        }
+                        if (signedInfo) {
+                            const lines = [];
+                            if (d.name) lines.push(`Nome firmatario: ${d.name}`);
+                            if (d.email) lines.push(`Email: ${d.email}`);
+                            if (d.timestamp) lines.push(`Data/ora: ${d.timestamp}`);
+                            if (d.ip) lines.push(`IP: ${d.ip}`);
+                            if (d.pdf_hash) lines.push(`Hash: ${d.pdf_hash}`);
+                            signedInfo.textContent = lines.join('\n');
+                            signedInfo.style.display = 'block';
                         }
                     }
                     if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, d.url);

--- a/static/app.js
+++ b/static/app.js
@@ -1991,9 +1991,9 @@ if (signaturePreview) {
     signaturePreview.addEventListener('dblclick', (e) => {
         handleSigPos(e.clientX, e.clientY);
     });
-    signaturePreview.addEventListener('touchstart', (e) => {
+    signaturePreview.addEventListener('touchend', (e) => {
         const now = Date.now();
-        const touch = e.touches[0];
+        const touch = e.changedTouches[0];
         if (now - lastSigTap < 300) {
             e.preventDefault();
             handleSigPos(touch.clientX, touch.clientY);

--- a/static/app.js
+++ b/static/app.js
@@ -42,6 +42,7 @@ let skipBlank = true;
 const processedImageElement = document.getElementById('processedImage');
 const processedGallery = document.getElementById('processedGallery');
 const statusMessageElement = document.getElementById('statusMessage');
+const signedPdfLink = document.getElementById('signedPdfLink');
 const reorderHint = document.getElementById('reorderHint');
 const imageModal = document.getElementById('imageModal');
 const modalImage = document.getElementById('modalImage');
@@ -159,6 +160,7 @@ let currentPdfBlob = null;
 window.lastSignEmail = '';
 window.lastSignPhone = '';
 window.lastSignToken = '';
+window.lastSignedUrl = '';
 let sortable = null;
 let currentFile = null;
 let docusealEnabled = false;
@@ -1665,6 +1667,7 @@ function generatePdf() {
         statusMessageElement.textContent = 'No processed images to export.';
         return;
     }
+    if (signedPdfLink) signedPdfLink.style.display = 'none';
     statusMessageElement.textContent = 'Generating PDF...';
     const layout = parseInt(layoutSelect.value || '1');
     const orientation = orientationSelect.value || 'portrait';
@@ -1706,7 +1709,14 @@ function generatePdf() {
                 })
                 .then(r => r.json())
                 .then(d => {
-                    if (d.url) window.lastSignedUrl = d.url;
+                    if (d.url) {
+                        window.lastSignedUrl = d.url;
+                        if (signedPdfLink) {
+                            signedPdfLink.href = d.url;
+                            signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
+                            signedPdfLink.style.display = 'inline';
+                        }
+                    }
                     if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, d.url);
                     if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, d.url);
                 });
@@ -1716,6 +1726,12 @@ function generatePdf() {
                 }
                 if (window.lastSignEmail) {
                     shareEmail(window.lastSignEmail);
+                }
+                if (signedPdfLink) {
+                    const url = URL.createObjectURL(currentPdfBlob);
+                    signedPdfLink.href = url;
+                    signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
+                    signedPdfLink.style.display = 'inline';
                 }
             }
         } else {

--- a/static/app.js
+++ b/static/app.js
@@ -897,6 +897,14 @@ async function shareWhatsApp(phone) {
     window.open(url, '_blank');
 }
 
+function shareWhatsAppLink(phone, link) {
+    if (!link) return;
+    phone = phone ? phone.replace(/[^0-9]/g, '') : '';
+    const wa = phone ? `https://wa.me/${phone}?text=${encodeURIComponent(link)}` :
+        `https://wa.me/?text=${encodeURIComponent(link)}`;
+    window.open(wa, '_blank');
+}
+
 async function shareEmail(email) {
     if (!currentPdfBlob) return;
     const file = new File([currentPdfBlob], 'DocCropper.pdf', { type: 'application/pdf' });
@@ -915,6 +923,13 @@ async function shareEmail(email) {
     const subject = encodeURIComponent('DocCropper PDF');
     const body = encodeURIComponent(translations['shareText'] || 'See attached document.');
     const mailto = `mailto:${email}?subject=${subject}&body=${body}`;
+    window.open(mailto, '_blank');
+}
+
+function shareEmailLink(email, link) {
+    if (!link) return;
+    const mail = email ? encodeURIComponent(email) : '';
+    const mailto = `mailto:${mail}?body=${encodeURIComponent(link)}`;
     window.open(mailto, '_blank');
 }
 
@@ -1688,13 +1703,20 @@ function generatePdf() {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ pdf: data.pdf })
+                })
+                .then(r => r.json())
+                .then(d => {
+                    if (d.url) window.lastSignedUrl = d.url;
+                    if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, d.url);
+                    if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, d.url);
                 });
-            }
-            if (window.lastSignPhone) {
-                shareWhatsApp(window.lastSignPhone);
-            }
-            if (window.lastSignEmail) {
-                shareEmail(window.lastSignEmail);
+            } else {
+                if (window.lastSignPhone) {
+                    shareWhatsApp(window.lastSignPhone);
+                }
+                if (window.lastSignEmail) {
+                    shareEmail(window.lastSignEmail);
+                }
             }
         } else {
             statusMessageElement.textContent = data.message || 'Failed to create PDF.';

--- a/static/app.js
+++ b/static/app.js
@@ -156,6 +156,8 @@ let editingIndex = null;
 let cameraStream = null;
 let cameraAvailable = false;
 let currentPdfBlob = null;
+window.lastSignEmail = '';
+window.lastSignPhone = '';
 let sortable = null;
 let currentFile = null;
 let docusealEnabled = false;
@@ -872,7 +874,7 @@ function cropImage(index) {
 }
 
 
-async function shareWhatsApp() {
+async function shareWhatsApp(phone) {
     if (!currentPdfBlob) return;
     const file = new File([currentPdfBlob], 'DocCropper.pdf', { type: 'application/pdf' });
     if (navigator.canShare && navigator.canShare({ files: [file] })) {
@@ -883,7 +885,9 @@ async function shareWhatsApp() {
             console.error('Web Share failed', e);
         }
     }
-    let phone = prompt(translations['enterPhone'] || 'Enter phone number (optional)');
+    if (!phone) {
+        phone = prompt(translations['enterPhone'] || 'Enter phone number (optional)');
+    }
     phone = phone ? phone.replace(/[^0-9]/g, '') : '';
     const encoded = encodeURIComponent(translations['shareText'] || 'See attached document.');
     const url = phone ?
@@ -892,7 +896,7 @@ async function shareWhatsApp() {
     window.open(url, '_blank');
 }
 
-async function shareEmail() {
+async function shareEmail(email) {
     if (!currentPdfBlob) return;
     const file = new File([currentPdfBlob], 'DocCropper.pdf', { type: 'application/pdf' });
     if (navigator.canShare && navigator.canShare({ files: [file] })) {
@@ -903,7 +907,9 @@ async function shareEmail() {
             console.error('Web Share failed', e);
         }
     }
-    let email = prompt(translations['enterEmail'] || 'Enter email address (optional)');
+    if (!email) {
+        email = prompt(translations['enterEmail'] || 'Enter email address (optional)');
+    }
     email = email ? encodeURIComponent(email) : '';
     const subject = encodeURIComponent('DocCropper PDF');
     const body = encodeURIComponent(translations['shareText'] || 'See attached document.');
@@ -1650,6 +1656,9 @@ function generatePdf() {
     const scale_mode = scaleMode.value || 'fit';
     const scale_percent = parseInt(scalePercent.value || '100');
     const payload = { images: processedImages, layout, orientation, arrangement, scale_mode, scale_percent, color_mode: globalColorMode, signature_image: signatureImageData, signatures };
+    if (window.lastSignEmail || window.lastSignPhone) {
+        payload.sign_info = { email: window.lastSignEmail, phone: window.lastSignPhone };
+    }
     fetch('/create-pdf/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -1673,6 +1682,12 @@ function generatePdf() {
             currentPdfBlob = new Blob([byteArray], {type: 'application/pdf'});
             exportOptions.style.display = 'block';
             statusMessageElement.textContent = 'PDF ready.';
+            if (window.lastSignPhone) {
+                shareWhatsApp(window.lastSignPhone);
+            }
+            if (window.lastSignEmail) {
+                shareEmail(window.lastSignEmail);
+            }
         } else {
             statusMessageElement.textContent = data.message || 'Failed to create PDF.';
         }
@@ -1798,14 +1813,14 @@ if (downloadPdfBtn) {
 
 if (waShareBtn) {
     waShareBtn.addEventListener('click', async () => {
-        await shareWhatsApp();
+        await shareWhatsApp(window.lastSignPhone);
         exportOptions.style.display = 'none';
     });
 }
 
 if (emailShareBtn) {
     emailShareBtn.addEventListener('click', async () => {
-        await shareEmail();
+        await shareEmail(window.lastSignEmail);
         exportOptions.style.display = 'none';
     });
 }

--- a/static/app.js
+++ b/static/app.js
@@ -158,6 +158,7 @@ let cameraAvailable = false;
 let currentPdfBlob = null;
 window.lastSignEmail = '';
 window.lastSignPhone = '';
+window.lastSignToken = '';
 let sortable = null;
 let currentFile = null;
 let docusealEnabled = false;
@@ -1682,6 +1683,13 @@ function generatePdf() {
             currentPdfBlob = new Blob([byteArray], {type: 'application/pdf'});
             exportOptions.style.display = 'block';
             statusMessageElement.textContent = 'PDF ready.';
+            if (window.lastSignToken) {
+                fetch('/store-signed-pdf/' + window.lastSignToken, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ pdf: data.pdf })
+                });
+            }
             if (window.lastSignPhone) {
                 shareWhatsApp(window.lastSignPhone);
             }

--- a/static/app.js
+++ b/static/app.js
@@ -880,24 +880,15 @@ function cropImage(index) {
 
 async function shareWhatsApp(phone) {
     if (!currentPdfBlob) return;
-    const file = new File([currentPdfBlob], 'DocCropper.pdf', { type: 'application/pdf' });
-    if (navigator.canShare && navigator.canShare({ files: [file] })) {
-        try {
-            await navigator.share({ files: [file], title: 'DocCropper PDF' });
-            return;
-        } catch (e) {
-            console.error('Web Share failed', e);
-        }
-    }
     if (!phone) {
         phone = prompt(translations['enterPhone'] || 'Enter phone number (optional)');
     }
     phone = phone ? phone.replace(/[^0-9]/g, '') : '';
-    const encoded = encodeURIComponent(translations['shareText'] || 'See attached document.');
-    const url = phone ?
-        `https://web.whatsapp.com/send?phone=${phone}&text=${encoded}` :
-        `https://web.whatsapp.com/send?text=${encoded}`;
-    window.open(url, '_blank');
+    const url = window.lastSignedUrl || URL.createObjectURL(currentPdfBlob);
+    const wa = phone ?
+        `https://wa.me/${phone}?text=${encodeURIComponent(url)}` :
+        `https://wa.me/?text=${encodeURIComponent(url)}`;
+    window.open(wa, '_blank');
 }
 
 function shareWhatsAppLink(phone, link) {
@@ -910,22 +901,12 @@ function shareWhatsAppLink(phone, link) {
 
 async function shareEmail(email) {
     if (!currentPdfBlob) return;
-    const file = new File([currentPdfBlob], 'DocCropper.pdf', { type: 'application/pdf' });
-    if (navigator.canShare && navigator.canShare({ files: [file] })) {
-        try {
-            await navigator.share({ files: [file], title: 'DocCropper PDF' });
-            return;
-        } catch (e) {
-            console.error('Web Share failed', e);
-        }
-    }
     if (!email) {
         email = prompt(translations['enterEmail'] || 'Enter email address (optional)');
     }
     email = email ? encodeURIComponent(email) : '';
-    const subject = encodeURIComponent('DocCropper PDF');
-    const body = encodeURIComponent(translations['shareText'] || 'See attached document.');
-    const mailto = `mailto:${email}?subject=${subject}&body=${body}`;
+    const url = window.lastSignedUrl || URL.createObjectURL(currentPdfBlob);
+    const mailto = `mailto:${email}?body=${encodeURIComponent(url)}`;
     window.open(mailto, '_blank');
 }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1991,11 +1991,11 @@ if (signaturePreview) {
     signaturePreview.addEventListener('dblclick', (e) => {
         handleSigPos(e.clientX, e.clientY);
     });
-    signaturePreview.addEventListener('touchend', (e) => {
+    signaturePreview.addEventListener('touchstart', (e) => {
         const now = Date.now();
+        const touch = e.touches[0];
         if (now - lastSigTap < 300) {
             e.preventDefault();
-            const touch = e.changedTouches[0];
             handleSigPos(touch.clientX, touch.clientY);
         }
         lastSigTap = now;

--- a/static/app.js
+++ b/static/app.js
@@ -159,6 +159,7 @@ let cameraAvailable = false;
 let currentPdfBlob = null;
 window.lastSignEmail = '';
 window.lastSignPhone = '';
+window.lastSignName = '';
 window.lastSignToken = '';
 window.lastSignedUrl = '';
 let sortable = null;
@@ -1675,8 +1676,8 @@ function generatePdf() {
     const scale_mode = scaleMode.value || 'fit';
     const scale_percent = parseInt(scalePercent.value || '100');
     const payload = { images: processedImages, layout, orientation, arrangement, scale_mode, scale_percent, color_mode: globalColorMode, signature_image: signatureImageData, signatures };
-    if (window.lastSignEmail || window.lastSignPhone) {
-        payload.sign_info = { email: window.lastSignEmail, phone: window.lastSignPhone };
+    if (window.lastSignEmail || window.lastSignPhone || window.lastSignName) {
+        payload.sign_info = { email: window.lastSignEmail, phone: window.lastSignPhone, name: window.lastSignName };
     }
     fetch('/create-pdf/', {
         method: 'POST',

--- a/static/index.html
+++ b/static/index.html
@@ -223,6 +223,7 @@
     </div>
     <p id="statusMessage"></p>
     <a id="signedPdfLink" style="display:none;" download="signed.pdf"></a>
+    <pre id="signedInfo" style="display:none;font-size:small;text-align:left;"></pre>
 
     <footer id="pageFooter">
         <div id="footerBrand">

--- a/static/index.html
+++ b/static/index.html
@@ -183,6 +183,10 @@
     <div id="mobileDetailsModal" class="modal" style="display:none;">
         <div class="modal-content" style="max-width:320px;text-align:center;padding:10px;">
             <label style="display:block;margin-bottom:5px;">
+                <span data-i18n="enterName"></span><br>
+                <input id="mobileNameInput" type="text" style="width:95%;">
+            </label>
+            <label style="display:block;margin-bottom:5px;">
                 <span data-i18n="enterEmail"></span><br>
                 <input id="mobileEmailInput" type="email" style="width:95%;">
             </label>

--- a/static/index.html
+++ b/static/index.html
@@ -177,7 +177,7 @@
         <button id="copySignLink" data-i18n="copyLink" data-i18n-title="copyLink" title="Copy link">Copy link</button>
         <button id="waSignLink" data-i18n="shareWhatsapp" data-i18n-title="shareWhatsapp" title="WhatsApp">WhatsApp</button>
         <button id="emailSignLink" data-i18n="shareEmail" data-i18n-title="shareEmail" title="Email">Email</button>
-        <p data-i18n="legalDisclaimer" class="legalWarning"></p>
+        <p data-i18n="mobileLegalNotice" class="legalWarning"></p>
     </div>
 
     <div id="mobileDetailsModal" class="modal" style="display:none;">

--- a/static/index.html
+++ b/static/index.html
@@ -218,6 +218,7 @@
         <span data-i18n="loading">Loading...</span>
     </div>
     <p id="statusMessage"></p>
+    <a id="signedPdfLink" style="display:none;" download="signed.pdf"></a>
 
     <footer id="pageFooter">
         <div id="footerBrand">

--- a/static/index.html
+++ b/static/index.html
@@ -176,7 +176,23 @@
         <a id="signQrLink" href="#" target="_blank"></a><br>
         <button id="copySignLink" data-i18n="copyLink" data-i18n-title="copyLink" title="Copy link">Copy link</button>
         <button id="waSignLink" data-i18n="shareWhatsapp" data-i18n-title="shareWhatsapp" title="WhatsApp">WhatsApp</button>
+        <button id="emailSignLink" data-i18n="shareEmail" data-i18n-title="shareEmail" title="Email">Email</button>
         <p data-i18n="legalDisclaimer" class="legalWarning"></p>
+    </div>
+
+    <div id="mobileDetailsModal" class="modal" style="display:none;">
+        <div class="modal-content" style="max-width:320px;text-align:center;padding:10px;">
+            <label style="display:block;margin-bottom:5px;">
+                <span data-i18n="enterEmail"></span><br>
+                <input id="mobileEmailInput" type="email" style="width:95%;">
+            </label>
+            <label style="display:block;margin-bottom:5px;">
+                <span data-i18n="enterPhone"></span><br>
+                <input id="mobilePhoneInput" type="tel" style="width:95%;">
+            </label>
+            <button id="mobileDetailsStart" data-i18n="startSign" style="margin-right:5px;">Start</button>
+            <button id="mobileDetailsCancel" data-i18n="cancel">Cancel</button>
+        </div>
     </div>
 
     <h2 data-i18n="processedImages">Processed Images:</h2>

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -146,6 +146,7 @@
   "docusealKey": "Docuseal key:",
   "publicUrl": "Public URL:",
   "legalDisclaimer": "DocCropper and its authors accept no liability for illegal use.",
+  "mobileLegalNotice": "\u26a0\ufe0f Legal warning \u2013 Simple Electronic Signature (SES)\nThe Mobile Sign system in DocCropper collects graphical signatures compliant with SES requirements under EU Regulation 910/2014 eIDAS and the Italian CAD. The signature is provided with explicit, traceable consent and is bound to the document. DocCropper and doccropper.iltuoconsulenteit.it are not qualified trust service providers, do not guarantee legal validity of collected signatures, do not store documents or logs unless customized, and accept no liability for improper use. The domain is for demo and testing only. Users must ensure compliance with applicable law, proper signer identification and use in contexts suitable for SES.",
   "signaturesSent": "Signatures sent. You may close this page.",
   "pageToSign": "Page to sign:",
   "loading": "Loading...",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -52,6 +52,7 @@
   "shareEmail": "Email",
   "enterPhone": "Enter phone number (optional)",
   "enterEmail": "Enter email address (optional)",
+  "enterName": "Enter full name (optional)",
   "shareText": "See attached document.",
   "digitalSign": "Digital Sign",
   "mobileSign": "Mobile Sign",

--- a/static/lang/en.json
+++ b/static/lang/en.json
@@ -55,6 +55,8 @@
   "shareText": "See attached document.",
   "digitalSign": "Digital Sign",
   "mobileSign": "Mobile Sign",
+  "startSign": "Start",
+  "cancel": "Cancel",
   "comingSoon": "Coming soon",
   "docusealError": "Docuseal request failed",
   "docusealLink": "Open the Docuseal link to sign",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -146,6 +146,7 @@
   "docusealKey": "Chiave Docuseal:",
   "publicUrl": "Dominio pubblico:",
   "legalDisclaimer": "DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.",
+  "mobileLegalNotice": "\u26a0\ufe0f Avvertenza legale \u2013 Firma elettronica semplice (FES)\nIl sistema di firma Mobile Sign, integrato in DocCropper, consente la raccolta di firme elettroniche grafiche in modalit\u00e0 conforme ai requisiti della FES, come definita dal Regolamento UE 910/2014 eIDAS e dal Codice dell'Amministrazione Digitale. La firma avviene con consenso esplicito e tracciabile ed \u00e8 associata al documento firmato. DocCropper e il sito doccropper.iltuoconsulenteit.it non sono prestatori di servizi fiduciari qualificati, non garantiscono la validit\u00e0 legale delle firme in ogni contesto, non conservano copie dei documenti o dei log se non con integrazione personalizzata e non assumono responsabilit\u00e0 per usi impropri. Il dominio \u00e8 destinato esclusivamente a scopi dimostrativi e di test. L'utente deve assicurarsi che l'uso avvenga nel rispetto della legge, con adeguata identificazione del firmatario e in contesti compatibili con la FES.",
   "signaturesSent": "Firme inviate. Puoi chiudere la pagina.",
   "pageToSign": "Pagina da firmare:",
   "loading": "Caricamento...",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -55,6 +55,8 @@
   "shareText": "In allegato il documento.",
   "digitalSign": "Firma digitale",
   "mobileSign": "Firma da mobile",
+  "startSign": "Avvia",
+  "cancel": "Annulla",
   "comingSoon": "Prossimamente",
   "docusealError": "Richiesta Docuseal fallita",
   "docusealLink": "Apri il link Docuseal per firmare",

--- a/static/lang/it.json
+++ b/static/lang/it.json
@@ -52,6 +52,7 @@
   "shareEmail": "Email",
   "enterPhone": "Inserisci numero di telefono (opzionale)",
   "enterEmail": "Inserisci indirizzo email (opzionale)",
+  "enterName": "Inserisci il nome completo (opzionale)",
   "shareText": "In allegato il documento.",
   "digitalSign": "Firma digitale",
   "mobileSign": "Firma da mobile",

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -6,6 +6,12 @@ export function initSignaturePlugin(translations, enabled = true) {
     const signQrLink = document.getElementById('signQrLink');
     const copySignLink = document.getElementById('copySignLink');
     const waSignLink = document.getElementById('waSignLink');
+    const emailSignLink = document.getElementById('emailSignLink');
+    const detailsModal = document.getElementById('mobileDetailsModal');
+    const detailsEmail = document.getElementById('mobileEmailInput');
+    const detailsPhone = document.getElementById('mobilePhoneInput');
+    const detailsStart = document.getElementById('mobileDetailsStart');
+    const detailsCancel = document.getElementById('mobileDetailsCancel');
     const signaturePage = document.getElementById('signaturePage');
     window.lastSignToken = '';
 
@@ -87,8 +93,27 @@ export function initSignaturePlugin(translations, enabled = true) {
             if (window.hideLoading) window.hideLoading();
         }
     }
+    function openDetailsModal() {
+        if (!detailsModal) { startQrSign(); return; }
+        if (detailsEmail) detailsEmail.value = window.lastSignEmail || '';
+        if (detailsPhone) detailsPhone.value = window.lastSignPhone || '';
+        detailsModal.style.display = 'block';
+    }
     if (mobileSignBtn) {
-        mobileSignBtn.addEventListener('click', startQrSign);
+        mobileSignBtn.addEventListener('click', openDetailsModal);
+    }
+    if (detailsStart) {
+        detailsStart.addEventListener('click', () => {
+            window.lastSignEmail = detailsEmail ? detailsEmail.value.trim() : '';
+            window.lastSignPhone = detailsPhone ? detailsPhone.value.trim() : '';
+            if (detailsModal) detailsModal.style.display = 'none';
+            startQrSign();
+        });
+    }
+    if (detailsCancel) {
+        detailsCancel.addEventListener('click', () => {
+            if (detailsModal) detailsModal.style.display = 'none';
+        });
     }
     if (signQR) {
         signQR.addEventListener('click', () => { signQR.style.display = 'none'; });
@@ -103,7 +128,19 @@ export function initSignaturePlugin(translations, enabled = true) {
         waSignLink.addEventListener('click', (e) => {
             e.stopPropagation();
             const url = signQrLink ? signQrLink.href : '';
-            window.open('https://wa.me/?text=' + encodeURIComponent(url), '_blank');
+            const phone = window.lastSignPhone ? window.lastSignPhone.replace(/[^0-9]/g, '') : '';
+            const wa = phone ? `https://wa.me/${phone}?text=${encodeURIComponent(url)}` :
+                `https://wa.me/?text=${encodeURIComponent(url)}`;
+            window.open(wa, '_blank');
+        });
+    }
+    if (emailSignLink) {
+        emailSignLink.addEventListener('click', (e) => {
+            e.stopPropagation();
+            const url = signQrLink ? signQrLink.href : '';
+            const mail = window.lastSignEmail ? encodeURIComponent(window.lastSignEmail) : '';
+            const mailto = `mailto:${mail}?body=${encodeURIComponent(url)}`;
+            window.open(mailto, '_blank');
         });
     }
 }

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -8,6 +8,7 @@ export function initSignaturePlugin(translations, enabled = true) {
     const waSignLink = document.getElementById('waSignLink');
     const emailSignLink = document.getElementById('emailSignLink');
     const detailsModal = document.getElementById('mobileDetailsModal');
+    const detailsName = document.getElementById('mobileNameInput');
     const detailsEmail = document.getElementById('mobileEmailInput');
     const detailsPhone = document.getElementById('mobilePhoneInput');
     const detailsStart = document.getElementById('mobileDetailsStart');
@@ -25,6 +26,7 @@ export function initSignaturePlugin(translations, enabled = true) {
             const resp = await fetch(`/signature-result/${token}`);
             if (resp.status === 200) {
                 const data = await resp.json();
+                window.lastSignName = data.name || '';
                 window.lastSignEmail = data.email || '';
                 window.lastSignPhone = data.phone || '';
                 if (data.signatures && typeof data.signatures === 'object') {
@@ -68,6 +70,7 @@ export function initSignaturePlugin(translations, enabled = true) {
             if (window.mobileSignPoints && Object.keys(window.mobileSignPoints).length) {
                 payload.points = window.mobileSignPoints;
             }
+            if (window.lastSignName) payload.name = window.lastSignName;
             if (window.lastSignEmail) payload.email = window.lastSignEmail;
             if (window.lastSignPhone) payload.phone = window.lastSignPhone;
             const resp = await fetch('/start-sign/', {
@@ -95,6 +98,7 @@ export function initSignaturePlugin(translations, enabled = true) {
     }
     function openDetailsModal() {
         if (!detailsModal) { startQrSign(); return; }
+        if (detailsName) detailsName.value = window.lastSignName || '';
         if (detailsEmail) detailsEmail.value = window.lastSignEmail || '';
         if (detailsPhone) detailsPhone.value = window.lastSignPhone || '';
         detailsModal.style.display = 'block';
@@ -104,6 +108,7 @@ export function initSignaturePlugin(translations, enabled = true) {
     }
     if (detailsStart) {
         detailsStart.addEventListener('click', () => {
+            window.lastSignName = detailsName ? detailsName.value.trim() : '';
             window.lastSignEmail = detailsEmail ? detailsEmail.value.trim() : '';
             window.lastSignPhone = detailsPhone ? detailsPhone.value.trim() : '';
             if (detailsModal) detailsModal.style.display = 'none';

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -18,6 +18,8 @@ export function initSignaturePlugin(translations, enabled = true) {
             const resp = await fetch(`/signature-result/${token}`);
             if (resp.status === 200) {
                 const data = await resp.json();
+                window.lastSignEmail = data.email || '';
+                window.lastSignPhone = data.phone || '';
                 if (data.signatures && typeof data.signatures === 'object') {
                     Object.keys(data.signatures).forEach(p => {
                         window.dispatchEvent(new CustomEvent('remoteSignature', {detail: {page: p, signatures: data.signatures[p]}}));

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -7,6 +7,7 @@ export function initSignaturePlugin(translations, enabled = true) {
     const copySignLink = document.getElementById('copySignLink');
     const waSignLink = document.getElementById('waSignLink');
     const signaturePage = document.getElementById('signaturePage');
+    window.lastSignToken = '';
 
     if (!enabled) {
         if (mobileSignBtn) mobileSignBtn.style.display = 'none';
@@ -61,6 +62,8 @@ export function initSignaturePlugin(translations, enabled = true) {
             if (window.mobileSignPoints && Object.keys(window.mobileSignPoints).length) {
                 payload.points = window.mobileSignPoints;
             }
+            if (window.lastSignEmail) payload.email = window.lastSignEmail;
+            if (window.lastSignPhone) payload.phone = window.lastSignPhone;
             const resp = await fetch('/start-sign/', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -75,6 +78,7 @@ export function initSignaturePlugin(translations, enabled = true) {
                     signQrLink.href = data.url;
                 }
                 signQR.style.display = 'block';
+                window.lastSignToken = data.token;
                 pollSignature(data.token);
             }
         } catch (e) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -292,7 +292,6 @@ button:hover {
 }
 
 .signPageBtn {
-    transform: rotate(-30deg);
     font-size: 1.2em;
 }
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -361,7 +361,7 @@ button:hover {
 .legalWarning {
     color: #a00;
     font-weight: bold;
-    margin-top: 5px;
+    margin-top: 1px;
 }
 
 #signatureHint {

--- a/static/styles.css
+++ b/static/styles.css
@@ -44,6 +44,7 @@ h1, h2 {
     min-width: 80px;
     text-align: center;
     margin: 0 auto;
+    order: 2;
 }
 
 #brandBox img {
@@ -694,7 +695,16 @@ button:hover {
     padding: 2px 0;
     width: 100%;
     flex-basis: 100%;
-    order: -1;
+    order: 1;
+}
+
+#mobileDetailsModal .modal-content {
+    background: #fff;
+    color: #333;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    border-radius: 6px;
 }
 
 #sponsorContent iframe {

--- a/static/styles.css
+++ b/static/styles.css
@@ -335,6 +335,7 @@ button:hover {
     border: 1px dashed #666;
     max-width: 100%;
     margin-top: 5px;
+    touch-action: manipulation;
 }
 
 #drawArea {

--- a/static/styles.css
+++ b/static/styles.css
@@ -695,7 +695,7 @@ button:hover {
     padding: 2px 0;
     width: 100%;
     flex-basis: 100%;
-    order: 103;
+    order: -1;
 }
 
 #sponsorContent iframe {


### PR DESCRIPTION
## Summary
- tweak legal disclaimer spacing
- add consent flag, email and phone fields on mobile sign page
- send data when finishing mobile signature

## Testing
- `python -m py_compile plugins/mobilesign/__init__.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_6888c3c2e9b48326a463631146c5dcf6