### PR TITLE
Fix header stacking on mobile

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -565,7 +565,7 @@ button:hover {
 
 @media (max-width: 600px) {
     #pageHeader {
-        flex-direction: column;
+        flex-direction: row;
     }
     #actionButtons {
         justify-content: center;


### PR DESCRIPTION
## Summary
- keep horizontal layout of the header on small screens

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6889d37deab08326a93c95633ce09a10