### PR TITLE
Enable drawing and mobile signatures in Expressive template

### DIFF
--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -123,7 +123,7 @@ def register(app, utils):
             </label>
             <button id='finish'>Finish</button>
         </div>
-        <div style='margin-top:20px;'><img src='/static/logos/footer_logo.png' style='max-width:120px' alt='IlTuoConsulenteIT'></div>
+        <div style='margin-top:20px;'><img src='/static/logos/footer_logo.png' style='max-height:20px' alt='IlTuoConsulenteIT'></div>
         <script>
         const padEl=document.getElementById('pad');
         const overlay=document.getElementById('overlay');
@@ -140,8 +140,15 @@ def register(app, utils):
         const scaleInput=document.getElementById('scaleRange');
         const container=document.getElementById('container');
         let scale=1;
+        let activeSign=null;
         if(scaleInput){
-            scaleInput.oninput=()=>{ scale=parseFloat(scaleInput.value); };
+            scaleInput.oninput=()=>{
+                scale=parseFloat(scaleInput.value);
+                if(activeSign){
+                    activeSign.scale=scale;
+                    positionAllSigns();
+                }
+            };
         }
         const images={images_json};
         const spots={spots_json};
@@ -197,6 +204,9 @@ def register(app, utils):
             let sx=0, sy=0, dragging=false;
             el.addEventListener('pointerdown',e=>{
                 dragging=true; sx=e.clientX; sy=e.clientY; el.setPointerCapture(e.pointerId);
+                activeSign=s;
+                if(scaleInput){ scaleInput.value=s.scale; }
+                scale=s.scale;
             });
             el.addEventListener('pointermove',e=>{
                 if(!dragging) return; const dx=e.clientX-sx; const dy=e.clientY-sy; const left=parseFloat(el.style.left)+dx; const top=parseFloat(el.style.top)+dy; el.style.left=left+'px'; el.style.top=top+'px'; const rect=docImg.getBoundingClientRect(); s.x=(left+el.offsetWidth/2)/rect.width; s.y=(top+el.offsetHeight/2)/rect.height; sx=e.clientX; sy=e.clientY;
@@ -220,6 +230,8 @@ def register(app, utils):
             pad.clear();
             padEl.style.display='none';
             drawSpots();
+            activeSign=sign;
+            if(scaleInput){ scaleInput.value=sign.scale; }
             return true;
         }
         submitBtn.onclick=placeCurrent;

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -450,14 +450,14 @@ def register(app, utils):
             return JSONResponse(status_code=404, content={'message': 'Not found'})
         with open(info_path, 'r') as fh:
             info = json.load(fh)
-        hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
         ts = info.get('timestamp') or datetime.utcnow().isoformat()
         name = info.get('name', '')
         ip = request.client.host or ''
         email = info.get('email', '')
         phone = info.get('phone', '')
         consent = info.get('consent', False)
-        legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS (UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
+        hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
+        legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS(UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
         try:
             doc = fitz.open(stream=pdf_bytes, filetype='pdf')
             try:
@@ -473,10 +473,11 @@ def register(app, utils):
                 info_page.insert_textbox(info_rect, text, fontsize=12, align=0)
             except Exception:
                 pass
-            pdf_bytes = doc.tobytes()
+            pdf_bytes = doc.tobytes(garbage=4, deflate=True)
             doc.close()
         except Exception:
             logging.exception('Failed to append legal text')
+        hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
         pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
         with open(pdf_path, 'wb') as fh:
             fh.write(pdf_bytes)

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -96,6 +96,7 @@ def register(app, utils):
         #pad{ border:1px solid #000; display:none; margin-top:10px; width:100%; height:200px }
         </style>
         <script src='https://cdn.jsdelivr.net/npm/signature_pad@4.1.5/dist/signature_pad.umd.min.js'></script>
+        <script src='https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js'></script>
         </head><body>
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
         <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
@@ -123,7 +124,7 @@ def register(app, utils):
             </label>
             <button id='finish'>Finish</button>
         </div>
-        <div style='margin-top:20px;'><img src='/static/logos/footer_logo.png' style='max-height:20px' alt='IlTuoConsulenteIT'></div>
+        <div style='margin-top:20px;'><img src='/static/logos/footer_logo.png' style='max-height:30px' alt='IlTuoConsulenteIT'></div>
         <script>
         const padEl=document.getElementById('pad');
         const overlay=document.getElementById('overlay');
@@ -239,10 +240,32 @@ def register(app, utils):
         const pdfLink=document.getElementById('pdfLink');
         const waPdfBtn=document.getElementById('waPdfBtn');
         const emailPdfBtn=document.getElementById('emailPdfBtn');
-        async function pollPdf(){
+
+        function loadImage(src){
+            return new Promise((res,rej)=>{const i=new Image();i.onload=()=>res(i);i.onerror=rej;i.src=src;});
+        }
+
+        async function generatePdf(){
             try{
-                const r=await fetch('/signed-pdf/{token}',{cache:'no-store'});
-                if(r.status===200){
+                const { jsPDF } = window.jspdf || {};
+                if(!jsPDF) throw new Error('jsPDF missing');
+                const imgs=[];
+                for(const src of images){ imgs.push(await loadImage(src)); }
+                const pdf=new jsPDF({orientation:'p',unit:'px',format:[imgs[0].width,imgs[0].height]});
+                imgs.forEach((img,idx)=>{
+                    if(idx>0) pdf.addPage([img.width,img.height]);
+                    pdf.addImage(img,'PNG',0,0,img.width,img.height);
+                    signs.filter(s=>s.page===idx).forEach(s=>{
+                        const h=img.height/10*s.scale;
+                        const w=h*(s.ratio||1);
+                        const x=s.x*img.width - w/2;
+                        const y=s.y*img.height - h/2;
+                        pdf.addImage(s.img,'PNG',x,y,w,h);
+                    });
+                });
+                const data=pdf.output('datauristring');
+                const r=await fetch('/store-signed-pdf/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pdf:data})});
+                if(r.ok){
                     const d=await r.json();
                     if(d.url){
                         pdfLink.href=d.url;
@@ -251,7 +274,7 @@ def register(app, utils):
                         finishMsg.textContent='Signatures sent. Download your PDF:';
                         if(waPdfBtn){
                             waPdfBtn.onclick=()=>{
-                                const p=(d.phone||'').replace(/[^0-9]/g,'');
+                                const p=(phoneInput.value||'').replace(/[^0-9]/g,'');
                                 const params=new URLSearchParams({text:d.url});
                                 if(p) params.set('phone',p);
                                 const u=`https://web.whatsapp.com/send?${params.toString()}`;
@@ -261,7 +284,7 @@ def register(app, utils):
                         }
                         if(emailPdfBtn){
                             emailPdfBtn.onclick=()=>{
-                                const m=d.email?encodeURIComponent(d.email):'';
+                                const m=emailInput.value?encodeURIComponent(emailInput.value):'';
                                 const mailto=`mailto:${m}?body=${encodeURIComponent(d.url)}`;
                                 window.open(mailto,'_blank');
                             };
@@ -270,8 +293,10 @@ def register(app, utils):
                         return;
                     }
                 }
-            }catch{}
-            setTimeout(pollPdf,3000);
+                finishMsg.textContent='PDF generation failed';
+            }catch(err){
+                finishMsg.textContent='PDF generation failed';
+            }
         }
         finishBtn.onclick=async()=>{
             if(finished) return;
@@ -282,13 +307,13 @@ def register(app, utils):
                 await fetch('/submit-signature/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({image:s.img,x:s.x,y:s.y,page:s.page,scale:s.scale})});
             }
             await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:nameInput.value||'',email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
-            finishMsg.textContent='Signatures sent. Waiting for PDF...';
+            finishMsg.textContent='Generating PDF...';
             finished=true;
             finishBtn.disabled=true;
             submitBtn.disabled=true;
             clearBtn.disabled=true;
             docImg.onclick=null;
-            pollPdf();
+            await generatePdf();
         };
         </script>
         </body></html>
@@ -430,12 +455,24 @@ def register(app, utils):
         name = info.get('name', '')
         ip = request.client.host or ''
         email = info.get('email', '')
+        phone = info.get('phone', '')
+        consent = info.get('consent', False)
         legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS (UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
         try:
             doc = fitz.open(stream=pdf_bytes, filetype='pdf')
-            page = doc[-1]
-            rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)
-            page.insert_textbox(rect, legal, fontsize=8, align=1)
+            try:
+                page = doc[-1]
+                rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)
+                page.insert_textbox(rect, legal, fontsize=8, align=1)
+            except Exception:
+                pass
+            try:
+                info_page = doc.new_page()
+                text = f"Nome: {name}\nEmail: {email}\nTelefono: {phone}\nData: {ts}\nSHA256: {hash_hex}\nConsenso: {consent}"
+                info_rect = fitz.Rect(50,50, info_page.rect.width-50, info_page.rect.height-50)
+                info_page.insert_textbox(info_rect, text, fontsize=12, align=0)
+            except Exception:
+                pass
             pdf_bytes = doc.tobytes()
             doc.close()
         except Exception:
@@ -465,7 +502,7 @@ def register(app, utils):
             json.dump(log_entry, fh, indent=2)
         if email:
             send_mail(email, 'Documento firmato', f'SHA256: {hash_hex}', pdf_path)
-        return {'status': 'ok', 'url': str(url)}
+        return {'status': 'ok', 'url': str(url), 'email': email, 'phone': phone}
 
     @app.get('/signed-pdf/{token}')
     async def signed_pdf(request: Request, token: str):

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -108,7 +108,8 @@ def register(app, utils):
         <button id='waPdfBtn' style='display:none;margin-left:10px;'>WhatsApp</button>
         <button id='emailPdfBtn' style='display:none;margin-left:10px;'>Email</button>
         <p>Tap the document then draw your signature</p>
-        <select id='pageSelect' style='margin-top:10px'></select>
+        <label for='pageSelect' style='display:block;margin-top:10px;'>Page:</label>
+        <select id='pageSelect' style='margin-top:4px'></select>
         <div id='container'>
             <img id='docImg' src='{img}' alt='doc'>
             <canvas id='overlay'></canvas>

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -99,6 +99,8 @@ def register(app, utils):
         </head><body>
         <img src='/static/logos/header_logo.png' style='max-width:150px;margin-top:10px' alt='DocCropper'>
         <p style='font-size:small;color:#a00;margin-top:5px;font-weight:bold'>DocCropper e i suoi autori declinano ogni responsabilità per un uso non conforme alla legge.<br>DocCropper and its authors accept no liability for illegal use.</p>
+        <label for='pageSelect' style='display:block;margin-top:10px;'>Page:</label>
+        <select id='pageSelect' style='margin-top:4px'></select>
         <label style='display:block;margin-top:5px;'><input type='checkbox' id='consentFlag'> Consento il trattamento dei dati</label>
         <input id='nameInput' type='text' placeholder='Nome' value='{name}' style='width:90%;max-width:300px;margin-top:5px;'>
         <input id='emailInput' type='email' placeholder='Email' value='{email}' style='width:90%;max-width:300px;margin-top:5px;'>
@@ -108,8 +110,6 @@ def register(app, utils):
         <button id='waPdfBtn' style='display:none;margin-left:10px;'>WhatsApp</button>
         <button id='emailPdfBtn' style='display:none;margin-left:10px;'>Email</button>
         <p>Tap the document then draw your signature</p>
-        <label for='pageSelect' style='display:block;margin-top:10px;'>Page:</label>
-        <select id='pageSelect' style='margin-top:4px'></select>
         <div id='container'>
             <img id='docImg' src='{img}' alt='doc'>
             <canvas id='overlay'></canvas>
@@ -138,12 +138,14 @@ def register(app, utils):
         const phoneInput=document.getElementById('phoneInput');
         const consentFlag=document.getElementById('consentFlag');
         const scaleInput=document.getElementById('scaleRange');
+        const container=document.getElementById('container');
         let scale=1;
         if(scaleInput){
             scaleInput.oninput=()=>{ scale=parseFloat(scaleInput.value); };
         }
         const images={images_json};
         const spots={spots_json};
+        const signs=[];
         async function loadPages(){
             try{
                 const resp=await fetch('/sign-pages/{token}');
@@ -156,8 +158,8 @@ def register(app, utils):
             }catch{}
             images.forEach((img,idx)=>{const opt=document.createElement('option');opt.value=idx;opt.textContent=(idx+1);pageSelect.appendChild(opt);});
             pageSelect.value={page};
+            docImg.onload=()=>{resize(); drawSpots(); positionAllSigns();};
             docImg.src=images[pageSelect.value];
-            drawSpots();
         }
         loadPages();
         let pos=null;
@@ -165,8 +167,9 @@ def register(app, utils):
         function resize(){
             padEl.width=window.innerWidth*0.9; padEl.height=200;
             overlay.width=docImg.clientWidth; overlay.height=docImg.clientHeight;
+            positionAllSigns();
         }
-        resize(); window.addEventListener('resize',resize);
+        window.addEventListener('resize',resize);
         const pad=new SignaturePad(padEl);
         function drawSpots(){
             const ctx=overlay.getContext('2d');
@@ -176,29 +179,50 @@ def register(app, utils):
             ctx.lineWidth=2;
             list.forEach(pt=>{const x=pt.x*overlay.width;const y=pt.y*overlay.height;ctx.beginPath();ctx.moveTo(x-10,y);ctx.lineTo(x+10,y);ctx.moveTo(x,y-10);ctx.lineTo(x,y+10);ctx.stroke();});
         }
-        pageSelect.onchange=()=>{ docImg.src=images[pageSelect.value]; drawSpots(); pos=null; };
+        function positionAllSigns(){
+            const rect=docImg.getBoundingClientRect();
+            signs.forEach(s=>{
+                const h=rect.height/10*s.scale;
+                const w=h*(s.ratio||1);
+                const x=s.x*rect.width - w/2;
+                const y=s.y*rect.height - h/2;
+                s.element.style.width=w+'px';
+                s.element.style.height=h+'px';
+                s.element.style.left=x+'px';
+                s.element.style.top=y+'px';
+                s.element.style.display = (s.page==parseInt(pageSelect.value)) ? 'block':'none';
+            });
+        }
+        function makeDraggable(el,s){
+            let sx=0, sy=0, dragging=false;
+            el.addEventListener('pointerdown',e=>{
+                dragging=true; sx=e.clientX; sy=e.clientY; el.setPointerCapture(e.pointerId);
+            });
+            el.addEventListener('pointermove',e=>{
+                if(!dragging) return; const dx=e.clientX-sx; const dy=e.clientY-sy; const left=parseFloat(el.style.left)+dx; const top=parseFloat(el.style.top)+dy; el.style.left=left+'px'; el.style.top=top+'px'; const rect=docImg.getBoundingClientRect(); s.x=(left+el.offsetWidth/2)/rect.width; s.y=(top+el.offsetHeight/2)/rect.height; sx=e.clientX; sy=e.clientY;
+            });
+            el.addEventListener('pointerup',e=>{ dragging=false; el.releasePointerCapture(e.pointerId); });
+        }
+        pageSelect.onchange=()=>{ docImg.onload=()=>{resize(); drawSpots(); positionAllSigns();}; docImg.src=images[pageSelect.value]; pos=null; };
         docImg.onclick=e=>{ if(finished) return; const r=e.target.getBoundingClientRect(); pos={x:(e.clientX-r.left)/r.width,y:(e.clientY-r.top)/r.height}; padEl.style.display='block'; controls.style.display='block'; };
         clearBtn.onclick=()=>pad.clear();
-        async function submitCurrent(){
+        function placeCurrent(){
             if(!pos||pad.isEmpty())return false;
             const img=pad.toDataURL('image/png');
-            await fetch('/submit-signature/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({image:img,x:pos.x,y:pos.y,page:parseInt(pageSelect.value),scale})});
-            const ctx=overlay.getContext('2d');
-            const tmp=new Image();
-            tmp.onload=()=>{
-                const w=tmp.width*(overlay.height/10)*scale/tmp.height;
-                const h=overlay.height/10*scale;
-                const x=pos.x*overlay.width - w/2;
-                const y=pos.y*overlay.height - h/2;
-                ctx.drawImage(tmp,x,y,w,h);
-            };
-            tmp.src=img;
+            const sign={img,x:pos.x,y:pos.y,scale:scale,page:parseInt(pageSelect.value)};
+            const el=new Image();
+            el.src=img; el.style.position='absolute'; el.style.touchAction='none';
+            sign.element=el;
+            el.onload=()=>{ sign.ratio=el.width/el.height; positionAllSigns(); };
+            makeDraggable(el,sign);
+            container.appendChild(el);
+            signs.push(sign);
             pad.clear();
             padEl.style.display='none';
             drawSpots();
             return true;
         }
-        submitBtn.onclick=submitCurrent;
+        submitBtn.onclick=placeCurrent;
         const finishMsg=document.getElementById('finishMsg');
         const pdfLink=document.getElementById('pdfLink');
         const waPdfBtn=document.getElementById('waPdfBtn');
@@ -237,9 +261,12 @@ def register(app, utils):
         }
         finishBtn.onclick=async()=>{
             if(finished) return;
-            if(!pad.isEmpty()) await submitCurrent();
+            if(!pad.isEmpty()) placeCurrent();
             finishMsg.textContent='Sending signatures...';
             finishMsg.style.display='block';
+            for(const s of signs){
+                await fetch('/submit-signature/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({image:s.img,x:s.x,y:s.y,page:s.page,scale:s.scale})});
+            }
             await fetch('/finish-signing/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({name:nameInput.value||'',email:emailInput.value||'',phone:phoneInput.value||'',consent:consentFlag.checked})});
             finishMsg.textContent='Signatures sent. Waiting for PDF...';
             finished=true;

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -240,7 +240,9 @@ def register(app, utils):
                         if(waPdfBtn){
                             waPdfBtn.onclick=()=>{
                                 const p=(d.phone||'').replace(/[^0-9]/g,'');
-                                const u=p?`https://wa.me/${p}?text=${encodeURIComponent(d.url)}`:`https://wa.me/?text=${encodeURIComponent(d.url)}`;
+                                const params=new URLSearchParams({text:d.url});
+                                if(p) params.set('phone',p);
+                                const u=`https://web.whatsapp.com/send?${params.toString()}`;
                                 window.open(u,'_blank');
                             };
                             waPdfBtn.style.display='inline';

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -254,7 +254,11 @@ def register(app, utils):
                 const pdf=new jsPDF({orientation:'p',unit:'px',format:[imgs[0].width,imgs[0].height]});
                 imgs.forEach((img,idx)=>{
                     if(idx>0) pdf.addPage([img.width,img.height]);
-                    pdf.addImage(img,'PNG',0,0,img.width,img.height);
+                    const c=document.createElement('canvas');
+                    c.width=img.width; c.height=img.height;
+                    c.getContext('2d').drawImage(img,0,0);
+                    const jpg=c.toDataURL('image/jpeg',0.85);
+                    pdf.addImage(jpg,'JPEG',0,0,img.width,img.height,'','FAST');
                     signs.filter(s=>s.page===idx).forEach(s=>{
                         const h=img.height/10*s.scale;
                         const w=h*(s.ratio||1);

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -464,6 +464,25 @@ def register(app, utils):
         legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS(UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
         try:
             doc = fitz.open(stream=pdf_bytes, filetype='pdf')
+            # Reapply recorded signatures to guarantee the server copy is signed
+            for sig in info.get('signatures', []) or []:
+                try:
+                    page_num = sig.get('page', info.get('page', 0))
+                    page = doc[page_num]
+                    img_path = sig.get('image_path')
+                    if not img_path or not os.path.exists(img_path):
+                        continue
+                    x = float(sig.get('x', 0.5))
+                    y = float(sig.get('y', 0.5))
+                    scale = float(sig.get('scale', 1.0))
+                    pix = fitz.Pixmap(img_path)
+                    h = page.rect.height / 10 * scale
+                    w = h * pix.width / pix.height
+                    x0 = x * page.rect.width - w / 2
+                    y0 = y * page.rect.height - h / 2
+                    page.insert_image(fitz.Rect(x0, y0, x0 + w, y0 + h), filename=img_path)
+                except Exception:
+                    continue
             try:
                 page = doc[-1]
                 rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -473,7 +473,13 @@ def register(app, utils):
                 info_page.insert_textbox(info_rect, text, fontsize=12, align=0)
             except Exception:
                 pass
-            pdf_bytes = doc.tobytes(garbage=4, deflate=True)
+            pdf_bytes = doc.tobytes(
+                clean=True,
+                garbage=4,
+                deflate=True,
+                deflate_images=True,
+                deflate_fonts=True,
+            )
             doc.close()
         except Exception:
             logging.exception('Failed to append legal text')

--- a/plugins/mobilesign/__init__.py
+++ b/plugins/mobilesign/__init__.py
@@ -271,11 +271,21 @@ def register(app, utils):
                 const r=await fetch('/store-signed-pdf/{token}',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({pdf:data})});
                 if(r.ok){
                     const d=await r.json();
-                    if(d.url){
+                    if(d.url&&d.hash){
+                        try{
+                            const fr=await fetch(d.url);
+                            const buf=await fr.arrayBuffer();
+                            const digest=await crypto.subtle.digest('SHA-256',buf);
+                            const hash=Array.from(new Uint8Array(digest)).map(b=>b.toString(16).padStart(2,'0')).join('');
+                            if(hash!==d.hash){
+                                finishMsg.textContent='Hash mismatch';
+                                return;
+                            }
+                        }catch{}
                         pdfLink.href=d.url;
                         pdfLink.textContent='Download PDF';
                         pdfLink.style.display='block';
-                        finishMsg.textContent='Signatures sent. Download your PDF:';
+                        finishMsg.textContent='Signatures sent. SHA256: '+d.hash;
                         if(waPdfBtn){
                             waPdfBtn.onclick=()=>{
                                 const p=(phoneInput.value||'').replace(/[^0-9]/g,'');
@@ -460,8 +470,6 @@ def register(app, utils):
         email = info.get('email', '')
         phone = info.get('phone', '')
         consent = info.get('consent', False)
-        hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
-        legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS(UE 910/2014). IP: {ip} | Email: {email} | SHA256: {hash_hex}"
         try:
             doc = fitz.open(stream=pdf_bytes, filetype='pdf')
             # Reapply recorded signatures to guarantee the server copy is signed
@@ -483,6 +491,21 @@ def register(app, utils):
                     page.insert_image(fitz.Rect(x0, y0, x0 + w, y0 + h), filename=img_path)
                 except Exception:
                     continue
+            doc_bytes = doc.tobytes(
+                clean=True,
+                garbage=4,
+                deflate=True,
+                deflate_images=True,
+                deflate_fonts=True,
+            )
+            doc.close()
+        except Exception:
+            logging.exception('Failed to reapply signatures')
+            doc_bytes = pdf_bytes
+        content_hash = hashlib.sha256(doc_bytes).hexdigest()
+        legal = f"Firmato elettronicamente in data {ts} da {name} con firma elettronica semplice ai sensi del Regolamento eIDAS(UE 910/2014). IP: {ip} | Email: {email} | SHA256: {content_hash}"
+        try:
+            doc = fitz.open(stream=doc_bytes, filetype='pdf')
             try:
                 page = doc[-1]
                 rect = fitz.Rect(50, page.rect.height - 40, page.rect.width - 50, page.rect.height - 10)
@@ -491,7 +514,7 @@ def register(app, utils):
                 pass
             try:
                 info_page = doc.new_page()
-                text = f"Nome: {name}\nEmail: {email}\nTelefono: {phone}\nData: {ts}\nSHA256: {hash_hex}\nConsenso: {consent}"
+                text = f"Nome: {name}\nEmail: {email}\nTelefono: {phone}\nData: {ts}\nSHA256: {content_hash}\nConsenso: {consent}"
                 info_rect = fitz.Rect(50,50, info_page.rect.width-50, info_page.rect.height-50)
                 info_page.insert_textbox(info_rect, text, fontsize=12, align=0)
             except Exception:
@@ -506,6 +529,7 @@ def register(app, utils):
             doc.close()
         except Exception:
             logging.exception('Failed to append legal text')
+            pdf_bytes = doc_bytes
         hash_hex = hashlib.sha256(pdf_bytes).hexdigest()
         pdf_path = os.path.join(signatures_dir, f'signed_{token}.pdf')
         with open(pdf_path, 'wb') as fh:
@@ -514,12 +538,14 @@ def register(app, utils):
         info['pdf_file'] = pdf_path
         info['pdf_url'] = str(url)
         info['pdf_hash'] = hash_hex
+        info['content_hash'] = content_hash
         with open(info_path, 'w') as fh:
             json.dump(info, fh)
         log_entry = {
             'token': token,
             'pdf_file': os.path.basename(pdf_path),
             'hash': hash_hex,
+            'content_hash': content_hash,
             'timestamp': ts,
             'ip': ip,
             'user_agent': request.headers.get('user-agent', ''),
@@ -531,8 +557,8 @@ def register(app, utils):
         with open(os.path.join('log_firme', f'firma_{token}.json'), 'w') as fh:
             json.dump(log_entry, fh, indent=2)
         if email:
-            send_mail(email, 'Documento firmato', f'SHA256: {hash_hex}', pdf_path)
-        return {'status': 'ok', 'url': str(url), 'email': email, 'phone': phone}
+            send_mail(email, 'Documento firmato', f'SHA256: {content_hash}', pdf_path)
+        return {'status': 'ok', 'url': str(url), 'hash': hash_hex, 'email': email, 'phone': phone}
 
     @app.get('/signed-pdf/{token}')
     async def signed_pdf(request: Request, token: str):
@@ -551,9 +577,9 @@ def register(app, utils):
                 return JSONResponse(status_code=202, content={'message': 'Pending'})
             url = request.url_for('download_signed_pdf', token=token)
             result['url'] = str(url)
-        for key in ('name', 'email', 'phone'):
+        for key in ('name', 'email', 'phone', 'pdf_hash'):
             if key in info:
-                result[key] = info[key]
+                result[key if key != 'pdf_hash' else 'hash'] = info[key]
         return result
 
     @app.get('/download-signed/{token}.pdf', name='download_signed_pdf')

--- a/static/app.js
+++ b/static/app.js
@@ -892,6 +892,10 @@ function openSignatureForPage(idx) {
     renderSignaturePreview();
 }
 
+// Expose signature helpers for global adapters
+window.openSignatureForPage = openSignatureForPage;
+window.startSign = () => openSignatureForPage(0);
+
 function cropImage(index) {
     editingIndex = index;
     const file = processedFiles[index];

--- a/static/app.js
+++ b/static/app.js
@@ -925,17 +925,18 @@ async function shareWhatsApp(phone) {
     }
     phone = phone ? phone.replace(/[^0-9]/g, '') : '';
     const url = window.lastSignedUrl || URL.createObjectURL(currentPdfBlob);
-    const wa = phone ?
-        `https://wa.me/${phone}?text=${encodeURIComponent(url)}` :
-        `https://wa.me/?text=${encodeURIComponent(url)}`;
+    const params = new URLSearchParams({ text: url });
+    if (phone) params.set('phone', phone);
+    const wa = `https://web.whatsapp.com/send?${params.toString()}`;
     window.open(wa, '_blank');
 }
 
 function shareWhatsAppLink(phone, link) {
     if (!link) return;
     phone = phone ? phone.replace(/[^0-9]/g, '') : '';
-    const wa = phone ? `https://wa.me/${phone}?text=${encodeURIComponent(link)}` :
-        `https://wa.me/?text=${encodeURIComponent(link)}`;
+    const params = new URLSearchParams({ text: link });
+    if (phone) params.set('phone', phone);
+    const wa = `https://web.whatsapp.com/send?${params.toString()}`;
     window.open(wa, '_blank');
 }
 
@@ -2154,6 +2155,8 @@ function addCurrentSignature() {
         mobileSignPoints[page].push({ x: signaturePosition.x, y: signaturePosition.y });
     } else {
         signatures.push({ page, x: signaturePosition.x, y: signaturePosition.y, scale: signatureScale });
+        const pageSigs = signatures.filter(s => s.page === page);
+        scaleTarget = (pageSigs.length - 1).toString();
     }
     const OFFSET = 0.05;
     signaturePosition.x += OFFSET;

--- a/static/app.js
+++ b/static/app.js
@@ -2034,7 +2034,7 @@ if (signaturePreview) {
         if (signatureImg) {
             signaturePosition.x = x;
             signaturePosition.y = y;
-            renderSignaturePreview();
+            addCurrentSignature();
         } else {
             pendingSigPos = { x, y };
             signatureModal.style.display = 'block';

--- a/static/app.js
+++ b/static/app.js
@@ -1740,24 +1740,14 @@ function generatePdf() {
             exportOptions.style.display = 'block';
             statusMessageElement.textContent = 'PDF ready.';
             if (window.lastSignToken) {
-                fetch('/store-signed-pdf/' + window.lastSignToken, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ pdf: data.pdf })
-                })
-                .then(r => r.json())
-                .then(d => {
-                    if (d.url) {
-                        window.lastSignedUrl = d.url;
-                        if (signedPdfLink) {
-                            signedPdfLink.href = d.url;
-                            signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
-                            signedPdfLink.style.display = 'inline';
-                        }
-                    }
-                    if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, d.url);
-                    if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, d.url);
-                });
+                const url = window.lastSignedUrl || URL.createObjectURL(currentPdfBlob);
+                if (signedPdfLink) {
+                    signedPdfLink.href = url;
+                    signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
+                    signedPdfLink.style.display = 'inline';
+                }
+                if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, url);
+                if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, url);
             } else {
                 if (window.lastSignPhone) {
                     shareWhatsApp(window.lastSignPhone);
@@ -2266,7 +2256,19 @@ async function applyRemoteSignature(data) {
 
 window.addEventListener('remoteSignature', (e) => applyRemoteSignature(e.detail));
 window.addEventListener('mobileSignComplete', () => {
-    if (exportPdfBtn) exportPdfBtn.click();
+    statusMessageElement.textContent = translations['waitingPdf'] || 'Waiting for signed PDF...';
+});
+window.addEventListener('signedPdfAvailable', (e) => {
+    const url = e.detail.url;
+    exportOptions.style.display = 'block';
+    if (signedPdfLink) {
+        signedPdfLink.href = url;
+        signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
+        signedPdfLink.style.display = 'inline';
+    }
+    statusMessageElement.textContent = translations['pdfReady'] || 'PDF ready.';
+    if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, url);
+    if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, url);
 });
 
 function updateImageFilters() {

--- a/static/app.js
+++ b/static/app.js
@@ -1702,11 +1702,12 @@ submitBtn.addEventListener('click', () => {
     });
 });
 
-function generatePdf() {
+async function generatePdf() {
     if (processedImages.length === 0) {
         statusMessageElement.textContent = 'No processed images to export.';
         return;
     }
+    await mergeAllSignatures();
     if (signedPdfLink) signedPdfLink.style.display = 'none';
     if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     statusMessageElement.textContent = 'Generating PDF...';
@@ -1785,7 +1786,7 @@ function generatePdf() {
 
 exportPdfBtn.addEventListener('click', async () => {
     await showSponsorModal();
-    generatePdf();
+    await generatePdf();
 });
 
 if (OCR_ENABLED) {
@@ -2234,6 +2235,49 @@ if (discardSignatureBtn) {
         };
         base.src = processedImages[pageIdx];
     });
+}
+
+async function mergeAllSignatures() {
+    if (!signatureImg) return;
+    const pages = new Set(signatures.map(s => s.page));
+    const current = parseInt(signaturePage.value || '0');
+    pages.add(current);
+    for (const page of pages) {
+        let stamps = signatures.filter(s => s.page === page);
+        if (page === current) {
+            stamps = stamps.concat([{ page, x: signaturePosition.x, y: signaturePosition.y, scale: signatureScale }]);
+        }
+        if (stamps.length === 0) continue;
+        const base = new Image();
+        await new Promise(res => { base.onload = res; base.src = processedImages[page]; });
+        const canvas = document.createElement('canvas');
+        canvas.width = base.width;
+        canvas.height = base.height;
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(base, 0, 0);
+        const baseRatio = (canvas.height / 10) / signatureImg.height;
+        for (const sig of stamps) {
+            const w = signatureImg.width * baseRatio * sig.scale;
+            const h = signatureImg.height * baseRatio * sig.scale;
+            const x = sig.x * canvas.width - w / 2;
+            const y = sig.y * canvas.height - h / 2;
+            ctx.drawImage(signatureImg, x, y, w, h);
+        }
+        const url = canvas.toDataURL('image/png');
+        processedImages[page] = url;
+        if (originalImages[page]) originalImages[page] = url;
+        const container = processedGallery.children[page];
+        if (container) container.querySelector('img').src = url;
+        try {
+            const blob = await (await fetch(url)).blob();
+            processedFiles[page] = new File([blob], processedFiles[page]?.name || `image_${page}.png`, { type: 'image/png' });
+        } catch {}
+    }
+    signatures = [];
+    signatureImageData = null;
+    signatureImg = null;
+    renderSignaturePreview();
+    updateSignatureTargetOptions();
 }
 
 async function applyRemoteSignature(data) {

--- a/static/app.js
+++ b/static/app.js
@@ -2328,6 +2328,9 @@ window.addEventListener('signedPdfAvailable', (e) => {
         signedPdfFrame.src = url;
         signedPdfFrame.style.display = 'block';
     }
+    if (e.detail.hash) {
+        window.lastPdfHash = e.detail.hash;
+    }
     statusMessageElement.textContent = translations['pdfReady'] || 'PDF ready.';
     if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, url);
     if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, url);

--- a/static/app.js
+++ b/static/app.js
@@ -883,6 +883,7 @@ function deleteImage(index) {
 function openSignatureForPage(idx) {
     populateSignaturePages();
     signaturePage.value = idx;
+    scaleTarget = 'current';
     updateSignatureTargetOptions();
     signatureControls.style.display = 'block';
     signatureExtra.style.display = 'block';
@@ -2403,6 +2404,9 @@ function updateSignatureTargetOptions() {
         signatureTargetSelect.appendChild(optAll);
     }
     signatureTargetSelect.value = scaleTarget;
+    if (signatureTargetSelect.value !== scaleTarget) {
+        scaleTarget = signatureTargetSelect.value;
+    }
     if (signatureScaleInput) {
         if (scaleTarget === 'current') {
             signatureScaleInput.value = signatureScale;

--- a/static/app.js
+++ b/static/app.js
@@ -43,6 +43,7 @@ const processedImageElement = document.getElementById('processedImage');
 const processedGallery = document.getElementById('processedGallery');
 const statusMessageElement = document.getElementById('statusMessage');
 const signedPdfLink = document.getElementById('signedPdfLink');
+const signedPdfFrame = document.getElementById('signedPdfFrame');
 const reorderHint = document.getElementById('reorderHint');
 const imageModal = document.getElementById('imageModal');
 const modalImage = document.getElementById('modalImage');
@@ -270,6 +271,7 @@ if (digitalSignBtn) {
             statusMessageElement.textContent = translations['docusealError'] || 'Docuseal request failed';
         }
         exportOptions.style.display = 'none';
+        if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     });
 }
 
@@ -1706,6 +1708,7 @@ function generatePdf() {
         return;
     }
     if (signedPdfLink) signedPdfLink.style.display = 'none';
+    if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     statusMessageElement.textContent = 'Generating PDF...';
     const layout = parseInt(layoutSelect.value || '1');
     const orientation = orientationSelect.value || 'portrait';
@@ -1746,6 +1749,10 @@ function generatePdf() {
                     signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
                     signedPdfLink.style.display = 'inline';
                 }
+                if (signedPdfFrame) {
+                    signedPdfFrame.src = url;
+                    signedPdfFrame.style.display = 'block';
+                }
                 if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, url);
                 if (window.lastSignEmail) shareEmailLink(window.lastSignEmail, url);
             } else {
@@ -1760,6 +1767,10 @@ function generatePdf() {
                     signedPdfLink.href = url;
                     signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
                     signedPdfLink.style.display = 'inline';
+                    if (signedPdfFrame) {
+                        signedPdfFrame.src = url;
+                        signedPdfFrame.style.display = 'block';
+                    }
                 }
             }
         } else {
@@ -1886,6 +1897,7 @@ if (downloadPdfBtn) {
         link.click();
         URL.revokeObjectURL(url);
         exportOptions.style.display = 'none';
+        if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     });
 }
 
@@ -1893,6 +1905,7 @@ if (waShareBtn) {
     waShareBtn.addEventListener('click', async () => {
         await shareWhatsApp(window.lastSignPhone);
         exportOptions.style.display = 'none';
+        if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     });
 }
 
@@ -1900,6 +1913,7 @@ if (emailShareBtn) {
     emailShareBtn.addEventListener('click', async () => {
         await shareEmail(window.lastSignEmail);
         exportOptions.style.display = 'none';
+        if (signedPdfFrame) signedPdfFrame.style.display = 'none';
     });
 }
 
@@ -2265,6 +2279,10 @@ window.addEventListener('signedPdfAvailable', (e) => {
         signedPdfLink.href = url;
         signedPdfLink.textContent = translations['downloadPdf'] || 'Download PDF';
         signedPdfLink.style.display = 'inline';
+    }
+    if (signedPdfFrame) {
+        signedPdfFrame.src = url;
+        signedPdfFrame.style.display = 'block';
     }
     statusMessageElement.textContent = translations['pdfReady'] || 'PDF ready.';
     if (window.lastSignPhone) shareWhatsAppLink(window.lastSignPhone, url);

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -13,7 +13,6 @@ export function initSignaturePlugin(translations, enabled = true) {
     const detailsPhone = document.getElementById('mobilePhoneInput');
     const detailsStart = document.getElementById('mobileDetailsStart');
     const detailsCancel = document.getElementById('mobileDetailsCancel');
-    const signaturePage = document.getElementById('signaturePage');
     window.lastSignToken = '';
 
     if (!enabled) {
@@ -60,18 +59,8 @@ export function initSignaturePlugin(translations, enabled = true) {
                 alert(translations['noFiles'] || 'No files available.');
                 return;
             }
-            if (signaturePage && signaturePage.options.length === 0) {
-                signaturePage.innerHTML = '';
-                for (let i = 0; i < images.length; i++) {
-                    const opt = document.createElement('option');
-                    opt.value = i;
-                    opt.textContent = (i + 1).toString();
-                    signaturePage.appendChild(opt);
-                }
-            }
-            const page = parseInt(signaturePage?.value || '0');
-            const payload = { page, images };
-            payload.image = images[page];
+            const payload = { page: 0, images };
+            payload.image = images[0];
             if (window.mobileSignPoints && Object.keys(window.mobileSignPoints).length) {
                 payload.points = window.mobileSignPoints;
             }
@@ -133,7 +122,18 @@ export function initSignaturePlugin(translations, enabled = true) {
     if (copySignLink) {
         copySignLink.addEventListener('click', (e) => {
             e.stopPropagation();
-            if (signQrLink) navigator.clipboard.writeText(signQrLink.href);
+            if (!signQrLink) return;
+            const text = signQrLink.href;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(text);
+            } else {
+                const tmp = document.createElement('textarea');
+                tmp.value = text;
+                document.body.appendChild(tmp);
+                tmp.select();
+                document.execCommand('copy');
+                document.body.removeChild(tmp);
+            }
         });
     }
     if (waSignLink) {

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -86,7 +86,7 @@ export function initSignaturePlugin(translations, enabled = true) {
                     signQrLink.textContent = data.url;
                     signQrLink.href = data.url;
                 }
-                signQR.style.display = 'block';
+                signQR.style.display = 'flex';
                 window.lastSignToken = data.token;
                 pollSignature(data.token);
             }
@@ -101,7 +101,7 @@ export function initSignaturePlugin(translations, enabled = true) {
         if (detailsName) detailsName.value = window.lastSignName || '';
         if (detailsEmail) detailsEmail.value = window.lastSignEmail || '';
         if (detailsPhone) detailsPhone.value = window.lastSignPhone || '';
-        detailsModal.style.display = 'block';
+        detailsModal.style.display = 'flex';
     }
     // Expose starter so global adapter can trigger the mobile signing flow
     window.startMobileSign = openDetailsModal;

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -134,6 +134,13 @@ export function initSignaturePlugin(translations, enabled = true) {
                 document.execCommand('copy');
                 document.body.removeChild(tmp);
             }
+            const original = copySignLink.textContent;
+            copySignLink.style.background = '#4ade80';
+            copySignLink.textContent = translations['copied'] || 'Copied!';
+            setTimeout(() => {
+                copySignLink.style.background = '#e5e7eb';
+                copySignLink.textContent = original;
+            }, 1200);
         });
     }
     if (waSignLink) {
@@ -141,8 +148,9 @@ export function initSignaturePlugin(translations, enabled = true) {
             e.stopPropagation();
             const url = signQrLink ? signQrLink.href : '';
             const phone = window.lastSignPhone ? window.lastSignPhone.replace(/[^0-9]/g, '') : '';
-            const wa = phone ? `https://wa.me/${phone}?text=${encodeURIComponent(url)}` :
-                `https://wa.me/?text=${encodeURIComponent(url)}`;
+            const params = new URLSearchParams({ text: url });
+            if (phone) params.set('phone', phone);
+            const wa = `https://web.whatsapp.com/send?${params.toString()}`;
             window.open(wa, '_blank');
         });
     }

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -20,6 +20,23 @@ export function initSignaturePlugin(translations, enabled = true) {
         return;
     }
 
+    async function pollPdf(token) {
+        try {
+            const r = await fetch(`/signed-pdf/${token}`);
+            if (r.status === 200) {
+                const d = await r.json();
+                if (d.url) {
+                    window.lastSignedUrl = d.url;
+                    window.dispatchEvent(new CustomEvent('signedPdfAvailable', { detail: d }));
+                    return;
+                }
+            }
+        } catch (err) {
+            console.error('pdf poll error', err);
+        }
+        setTimeout(() => pollPdf(token), 3000);
+    }
+
     async function pollSignature(token) {
         try {
             const resp = await fetch(`/signature-result/${token}`);
@@ -37,6 +54,7 @@ export function initSignaturePlugin(translations, enabled = true) {
                 }
                 window.dispatchEvent(new Event('mobileSignComplete'));
                 signQR.style.display = 'none';
+                pollPdf(token);
                 return;
             } else if (resp.status === 202) {
                 setTimeout(() => pollSignature(token), 3000);

--- a/static/plugins/mobilesign.js
+++ b/static/plugins/mobilesign.js
@@ -53,8 +53,13 @@ export function initSignaturePlugin(translations, enabled = true) {
     async function startQrSign() {
         if (window.showLoading) window.showLoading(translations['loading'] || 'Loading...');
         try {
-            const images = window.processedImages || [];
-            if (!images.length) return;
+            const images = typeof window.getProcessedImages === 'function'
+                ? window.getProcessedImages()
+                : (window.processedImages || []);
+            if (!images.length) {
+                alert(translations['noFiles'] || 'No files available.');
+                return;
+            }
             if (signaturePage && signaturePage.options.length === 0) {
                 signaturePage.innerHTML = '';
                 for (let i = 0; i < images.length; i++) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -205,7 +205,7 @@ button:hover {
 }
 
 #footerLogo {
-    max-height: 40px;
+    max-height: 20px;
     margin-left: 10px;
 }
 

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -240,7 +240,6 @@
     </div>
     <div id="mobileDetailsModal" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center;">
       <div style="background:#fff; padding:1rem; border-radius:0.25rem; width:18rem; text-align:center; display:flex; flex-direction:column; gap:0.5rem;">
-        <select id="signaturePage" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;"></select>
         <input id="mobileNameInput" type="text" placeholder="Name" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />
         <input id="mobileEmailInput" type="email" placeholder="Email" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />
         <input id="mobilePhoneInput" type="tel" placeholder="Phone" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>DocCropper Expressive</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.2/dist/tailwind.min.css" rel="stylesheet" />
+    <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/2.14.305/pdf.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/interactjs@1.10.11/dist/interact.min.js"></script>
@@ -41,7 +41,7 @@
             <button class="w-full text-left p-2 hover:bg-gray-700" @click="command('sign')" x-text="t('sign')"></button>
           </li>
           <li>
-            <button class="w-full text-left p-2 hover:bg-gray-700" @click="command('mobileSign')" x-text="t('mobileSign')"></button>
+            <button id="mobileSignBtn" class="w-full text-left p-2 hover:bg-gray-700" @click="command('mobileSign')" x-text="t('mobileSign')"></button>
           </li>
         </ul>
         <h2 class="px-4 mt-4 text-xs uppercase text-gray-400" x-text="t('navigation')"></h2>
@@ -159,6 +159,7 @@
       <div class="bg-white p-4 rounded">
         <div class="flex gap-4">
           <div class="relative" x-ref="signWrap">
+            <p class="text-xs text-gray-500 mb-1" x-text="t('dblClickHint') || 'Double click the image to add your signature'"></p>
             <img x-ref="signImg" :src="files[signIndex]?.url" @dblclick.stop="addSignature($event)" class="max-w-full max-h-[70vh] cursor-crosshair" />
             <template x-for="(sig,i) in signatures.filter(s=>s.page===signIndex)" :key="i">
               <img :id="'sig'+i" :src="signatureImageData" class="absolute cursor-move" @mousedown.stop="selectSig(i)">
@@ -170,6 +171,7 @@
           </div>
           <div class="flex flex-col space-y-2 w-40 text-xs">
             <input type="file" accept="image/*" @change="loadSignature" class="text-xs">
+            <button @click="drawModal=true" class="px-2 py-1 bg-gray-200 rounded" x-text="t('draw') || 'Draw'"></button>
             <label class="flex items-center gap-1"><input type="checkbox" x-model="removeSigBg" @change="window.removeSignatureBackground = removeSigBg"><span x-text="t('removeBg')"></span></label>
             <div class="border-t pt-2 space-y-1">
               <template x-for="(sig,i) in signatures.filter(s=>s.page===signIndex)" :key="'list'+i">
@@ -184,6 +186,17 @@
               <button @click="closeSign" class="bg-gray-300 px-2 py-1 rounded" x-text="t('cancel')"></button>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Draw Modal -->
+    <div x-show="drawModal" class="fixed inset-0 bg-black/50 flex items-center justify-center">
+      <div class="bg-white p-4 rounded">
+        <canvas x-ref="drawCanvas" width="300" height="150" class="border" @mousedown="startDraw($event)" @mousemove="moveDraw($event)" @mouseup="endDraw" @mouseleave="endDraw" @touchstart.prevent="startDraw($event)" @touchmove.prevent="moveDraw($event)" @touchend="endDraw"></canvas>
+        <div class="mt-2 flex justify-end gap-2 text-sm">
+          <button @click="clearDraw" class="px-2 py-1 bg-gray-200 rounded" x-text="t('clear') || 'Clear'"></button>
+          <button @click="useDraw" class="px-2 py-1 bg-blue-500 text-white rounded" x-text="t('apply')"></button>
         </div>
       </div>
     </div>
@@ -215,25 +228,25 @@
     </div>
 
     <!-- Mobile Sign Overlay and Details Modal -->
-    <div id="signQR" style="display:none;" class="fixed inset-0 bg-black/70 flex flex-col items-center justify-center p-4 text-center">
-      <img id="signQrImg" class="max-w-xs mb-2" alt="QR" />
-      <p id="signQrHint" class="text-white text-sm mb-2"></p>
-      <a id="signQrLink" href="#" target="_blank" class="break-all text-blue-300 underline mb-2"></a>
-      <div class="space-x-2">
-        <button id="copySignLink" class="px-2 py-1 bg-gray-200 rounded">Copy</button>
-        <button id="waSignLink" class="px-2 py-1 bg-green-500 text-white rounded">WhatsApp</button>
-        <button id="emailSignLink" class="px-2 py-1 bg-blue-500 text-white rounded">Email</button>
+    <div id="signQR" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.7); padding:1rem; text-align:center; align-items:center; justify-content:center; flex-direction:column;">
+      <img id="signQrImg" alt="QR" style="max-width:20rem; margin-bottom:0.5rem;" />
+      <p id="signQrHint" style="color:#fff; font-size:0.875rem; margin-bottom:0.5rem;"></p>
+      <a id="signQrLink" href="#" target="_blank" style="word-break:break-all; color:#93c5fd; text-decoration:underline; margin-bottom:0.5rem;"></a>
+      <div style="display:flex; gap:0.5rem;">
+        <button id="copySignLink" style="padding:0.25rem 0.5rem; background:#e5e7eb; border-radius:0.25rem;">Copy</button>
+        <button id="waSignLink" style="padding:0.25rem 0.5rem; background:#22c55e; color:#fff; border-radius:0.25rem;">WhatsApp</button>
+        <button id="emailSignLink" style="padding:0.25rem 0.5rem; background:#3b82f6; color:#fff; border-radius:0.25rem;">Email</button>
       </div>
     </div>
-    <div id="mobileDetailsModal" style="display:none;" class="fixed inset-0 bg-black/50 flex items-center justify-center">
-      <div class="bg-white p-4 rounded w-72 space-y-2 text-center">
-        <select id="signaturePage" class="border w-full p-1"></select>
-        <input id="mobileNameInput" type="text" placeholder="Name" class="border w-full p-1" />
-        <input id="mobileEmailInput" type="email" placeholder="Email" class="border w-full p-1" />
-        <input id="mobilePhoneInput" type="tel" placeholder="Phone" class="border w-full p-1" />
-        <div class="pt-2 space-x-2">
-          <button id="mobileDetailsStart" class="bg-blue-500 text-white px-3 py-1 rounded">Start</button>
-          <button id="mobileDetailsCancel" class="bg-gray-300 px-3 py-1 rounded">Cancel</button>
+    <div id="mobileDetailsModal" style="display:none; position:fixed; top:0; left:0; right:0; bottom:0; background:rgba(0,0,0,0.5); align-items:center; justify-content:center;">
+      <div style="background:#fff; padding:1rem; border-radius:0.25rem; width:18rem; text-align:center; display:flex; flex-direction:column; gap:0.5rem;">
+        <select id="signaturePage" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;"></select>
+        <input id="mobileNameInput" type="text" placeholder="Name" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />
+        <input id="mobileEmailInput" type="email" placeholder="Email" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />
+        <input id="mobilePhoneInput" type="tel" placeholder="Phone" style="border:1px solid #d1d5db; width:100%; padding:0.25rem;" />
+        <div style="padding-top:0.5rem; display:flex; gap:0.5rem; justify-content:center;">
+          <button id="mobileDetailsStart" style="background:#3b82f6; color:#fff; padding:0.25rem 0.75rem; border-radius:0.25rem;">Start</button>
+          <button id="mobileDetailsCancel" style="background:#d1d5db; padding:0.25rem 0.75rem; border-radius:0.25rem;">Cancel</button>
         </div>
       </div>
     </div>
@@ -341,6 +354,9 @@
           lastTap:0,
           files:[],
           signModal:false,
+          drawModal:false,
+          drawing:false,
+          lastPoint:null,
           signIndex:null,
           signatureImageData:null,
           signatures:[],
@@ -672,6 +688,41 @@
             if(this.activeSig===i) this.activeSig=null;
             else if(this.activeSig>i) this.activeSig--;
             this.renderSignatures();
+          },
+          getDrawPos(e){
+            const rect=this.$refs.drawCanvas.getBoundingClientRect();
+            const x=(e.touches?e.touches[0].clientX:e.clientX)-rect.left;
+            const y=(e.touches?e.touches[0].clientY:e.clientY)-rect.top;
+            return {x,y};
+          },
+          startDraw(e){ this.drawing=true; this.lastPoint=this.getDrawPos(e); },
+          moveDraw(e){
+            if(!this.drawing) return;
+            const ctx=this.$refs.drawCanvas.getContext('2d');
+            const p=this.getDrawPos(e);
+            ctx.beginPath();
+            ctx.moveTo(this.lastPoint.x,this.lastPoint.y);
+            ctx.lineTo(p.x,p.y);
+            ctx.stroke();
+            this.lastPoint=p;
+          },
+          endDraw(){ this.drawing=false; },
+          clearDraw(){
+            const c=this.$refs.drawCanvas;
+            c.getContext('2d').clearRect(0,0,c.width,c.height);
+          },
+          useDraw(){
+            const data=this.$refs.drawCanvas.toDataURL('image/png');
+            this.signatureImageData=data;
+            window.signatureImageData=data;
+            const img=new Image();
+            img.onload=()=>{
+              this.signatureAspect=img.height/img.width;
+              window.signatureAspect=this.signatureAspect;
+              this.renderSignatures();
+            };
+            img.src=data;
+            this.drawModal=false;
           },
           saveSignModal(){
             this.signModal=false;

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -437,6 +437,7 @@
             window.startSign = () => {
               if (this.files.length > 0) this.signPage(0);
             };
+            window.getProcessedImages = () => this.files.map(f => f.url);
           },
           async command(action){
             if(!this.pinned) this.drawer=false;

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -14,6 +14,33 @@
       main::-webkit-scrollbar-track { background: #f3f4f6; }
       main::-webkit-scrollbar-thumb { background-color: #9ca3af; border-radius: 8px; }
       main { scrollbar-width: auto; scrollbar-color: #9ca3af #f3f4f6; }
+      #exportOptions {
+        position: fixed;
+        right: 10px;
+        bottom: 10px;
+        background: #fff;
+        border: 1px solid #888;
+        padding: 10px;
+        z-index: 1000;
+        text-align: center;
+      }
+      #exportOptions button {
+        margin: 5px;
+      }
+      #layoutPreview {
+        width: 180px;
+        height: 220px;
+        border: 1px dashed #666;
+        margin-top: 10px;
+        display: none;
+        gap: 4px;
+      }
+      #layoutPreview.visible {
+        display: grid;
+      }
+      #layoutPreview .cell {
+        border: 1px solid #aaa;
+      }
     </style>
   </head>
   <body x-data="dcApp()" class="h-screen flex">
@@ -855,7 +882,7 @@
               .then(d=>{ if(d.processed_image){ this.files[this.cropIndex].url=d.processed_image; this.files[this.cropIndex].original=d.processed_image; this.files=[...this.files]; } })
               .finally(()=>{ this.closeCrop(); });
           },
-          initSortable(){
+      initSortable(){
             if(!this.$refs.fileGrid) return;
             if(this.sortable){ this.sortable.destroy(); }
             this.sortable = Sortable.create(this.$refs.fileGrid, {
@@ -872,6 +899,47 @@
         }
       }
     </script>
+    <div id="exportOptions" style="display:none;">
+      <a id="signedPdfLink" style="display:none; margin-bottom:8px; color:#2563eb; text-decoration:underline;" download="signed.pdf"></a>
+      <div id="layoutControls" style="display:none; text-align:left; margin-bottom:8px;">
+        <button id="togglePreviewBtn">Preview layout</button>
+        <label for="layoutSelect">Images per page:</label>
+        <select id="layoutSelect">
+          <option value="1">1</option>
+          <option value="2">2</option>
+          <option value="4">4</option>
+        </select>
+        <label for="orientationSelect">Orientation:</label>
+        <select id="orientationSelect">
+          <option value="portrait">Portrait</option>
+          <option value="landscape">Landscape</option>
+        </select>
+        <label for="arrangeSelect">Layout:</label>
+        <select id="arrangeSelect">
+          <option value="auto">Auto</option>
+          <option value="horizontal">Horizontal</option>
+          <option value="vertical">Vertical</option>
+          <option value="grid">Grid</option>
+        </select>
+        <label for="scaleMode">Image size:</label>
+        <select id="scaleMode">
+          <option value="fit">Fill cell</option>
+          <option value="original">Original</option>
+          <option value="percent">Scale (%)</option>
+        </select>
+        <input type="number" id="scalePercent" value="100" min="10" max="300" step="10" style="width:60px; display:none;">
+        <label for="colorModeSelect">Color mode:</label>
+        <select id="colorModeSelect">
+          <option value="color">Color</option>
+          <option value="gray">Grayscale</option>
+          <option value="bw">B/W</option>
+        </select>
+      </div>
+      <div id="layoutPreview"></div>
+      <button id="downloadPdfBtn">Download PDF</button>
+      <button id="waShareBtn">WhatsApp</button>
+      <button id="emailShareBtn">Email</button>
+    </div>
     <script type="module">
       import { initSignaturePlugin } from '/static/plugins/mobilesign.js';
       const lang = window.DC_LANG || document.documentElement.lang || 'en';

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -946,6 +946,38 @@
       const lang = window.DC_LANG || document.documentElement.lang || 'en';
       const trans = (window.dcStrings && window.dcStrings[lang]) ? window.dcStrings[lang] : {};
       initSignaturePlugin(trans, true);
+      window.addEventListener('signedPdfAvailable', (e) => {
+        const url = e.detail.url;
+        const exportBox = document.getElementById('exportOptions');
+        const link = document.getElementById('signedPdfLink');
+        const frame = document.getElementById('signedPdfFrame');
+        const waBtn = document.getElementById('waShareBtn');
+        const emailBtn = document.getElementById('emailShareBtn');
+        if (exportBox) exportBox.style.display = 'block';
+        if (link) {
+          link.href = url;
+          link.textContent = trans['downloadPdf'] || 'Download PDF';
+          link.style.display = 'inline';
+        }
+        if (frame) {
+          frame.src = url;
+          frame.style.display = 'block';
+        }
+        if (waBtn) {
+          waBtn.onclick = () => {
+            const p = (window.lastSignPhone || '').replace(/[^0-9]/g, '');
+            const params = new URLSearchParams({ text: url });
+            if (p) params.set('phone', p);
+            window.open(`https://web.whatsapp.com/send?${params.toString()}`, '_blank');
+          };
+        }
+        if (emailBtn) {
+          emailBtn.onclick = () => {
+            const m = window.lastSignEmail ? encodeURIComponent(window.lastSignEmail) : '';
+            window.open(`mailto:${m}?body=${encodeURIComponent(url)}`, '_blank');
+          };
+        }
+      });
     </script>
   </body>
 </html>

--- a/templates/expressive/index.html
+++ b/templates/expressive/index.html
@@ -901,6 +901,7 @@
     </script>
     <div id="exportOptions" style="display:none;">
       <a id="signedPdfLink" style="display:none; margin-bottom:8px; color:#2563eb; text-decoration:underline;" download="signed.pdf"></a>
+      <iframe id="signedPdfFrame" style="display:none; width:100%; height:300px; border:1px solid #666; margin-bottom:8px;"></iframe>
       <div id="layoutControls" style="display:none; text-align:left; margin-bottom:8px;">
         <button id="togglePreviewBtn">Preview layout</button>
         <label for="layoutSelect">Images per page:</label>


### PR DESCRIPTION
## Summary
- Add explicit mobile-sign button hook in Expressive sidebar
- Replace Tailwind-dependent mobile signing modal with inline styling for broader compatibility
- Ensure mobile signing overlay uses flex layout when shown

## Testing
- `node --check static/app.js && node --check static/plugins/mobilesign.js`
- `python -m py_compile main.py plugins/sign/__init__.py plugins/mobilesign/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_689b0db9400c8326b8edee3a1cd02f22