### PR TITLE
chore: mark PNG slides as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 *.bat text eol=crlf
+
+*.png binary


### PR DESCRIPTION
## Summary
- mark PNG images as binary

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f0cca5930832682e910379dab03fd