### PR TITLE
Persist license metadata from remote checks

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -127,3 +127,26 @@ source control. Back up the database if you need to preserve accounts before upd
 - `update_interval` – interval between automatic update checks (milliseconds)
 
 User preferences are stored per account in the `users/` folder.  If a setting is defined in both the environment and `settings.json`, the environment variable takes precedence.
+
+## `license_overrides.json`
+`license_overrides.json` is created automatically after a successful remote license check.  The file contains values that the license server enforces and therefore override any corresponding entries in `settings.json`.
+
+Typical fields include:
+
+- `license_key` – the validated key
+- `license_name` – name associated with the license
+- `license_level` – tier such as `free`, `pro`, `full`, or `developer`
+- Other enforced options like plugin flags or user limits
+
+Example:
+
+```json
+{
+  "license_key": "ABCD-1234",
+  "license_name": "Example Corp",
+  "license_level": "pro",
+  "lan_user_limit": 5
+}
+```
+
+This file is managed by the application and should not be edited manually.

--- a/main.py
+++ b/main.py
@@ -130,9 +130,27 @@ def load_license_overrides() -> dict:
     except Exception:
         return {}
 
-def save_license_overrides(update: dict) -> dict:
+def save_license_overrides(
+    update: dict,
+    key: str | None = None,
+    name: str | None = None,
+    level: str | None = None,
+) -> dict:
+    """Persist license-enforced settings and metadata.
+
+    ``update`` may contain arbitrary settings that the license server forces.
+    When ``key``, ``name`` or ``level`` are provided they are also written so
+    subsequent calls to :func:`load_settings` expose the current license
+    information to the frontend.
+    """
     data = load_license_overrides()
     data.update(update)
+    if key:
+        data["license_key"] = key
+    if name:
+        data["license_name"] = name
+    if level:
+        data["license_level"] = level
     with open(LICENSE_OVERRIDES_FILE, "w") as fh:
         json.dump(data, fh)
     return data
@@ -479,10 +497,10 @@ def load_settings():
         if not merged.get("settings_password_hash"):
             merged["settings_password_hash"] = bcrypt_hash(DEFAULT_SETTINGS_PASSWORD)
 
-        # Apply values enforced by a previous license check
+        # Apply values enforced by a previous license check, including
+        # license metadata saved by ``save_license_overrides``
         overrides = load_license_overrides()
-        if overrides:
-            merged.update(overrides)
+        merged.update(overrides)
 
         dev_env = get_dev_license_key()
         key_upper = merged.get("license_key", "").strip().upper()
@@ -738,7 +756,16 @@ async def require_valid_license(
             save_settings(updates)
 
     forced = data.get("settings", {})
-    if isinstance(forced, dict) and forced:
+    forced = forced if isinstance(forced, dict) else {}
+    license_fields = {
+        k: data.get(k)
+        for k in ("license_key", "license_name", "license_level")
+        if data.get(k) is not None
+    }
+    if license_fields.get("license_level"):
+        license_fields["license_level"] = license_fields["license_level"].lower()
+    if forced or license_fields:
+        forced.update(license_fields)
         save_license_overrides(forced)
 
     settings = load_settings()


### PR DESCRIPTION
## Summary
- persist license_key, license_name and license_level in license_overrides.json
- always load license override metadata when returning settings
- document the license_overrides.json format

## Testing
- `python -m py_compile main.py`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'uvicorn'; No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b1833ec4d88326b0d788e50cee0906