### PR TITLE
Initialize auth DB on startup and document backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,27 @@ The SQLite file (`db.sqlite3`) stores authentication data and is ignored by Git.
 Install scripts remove this file during updates to avoid merge conflicts; if you
 need to preserve accounts, back up the database before running an update.
 
+### Backup e migrazioni del database
+
+Per salvare una copia di sicurezza è sufficiente duplicare il file SQLite:
+
+```bash
+cp db.sqlite3 db.sqlite3.bak
+# oppure con l'utilità integrata di SQLite
+sqlite3 db.sqlite3 ".backup 'db.sqlite3.bak'"
+```
+
+Se i modelli cambiano, le tabelle possono essere aggiornate con uno strumento
+di migrazione come [Alembic](https://alembic.sqlalchemy.org/):
+
+```bash
+alembic revision --autogenerate -m "messaggio"
+alembic upgrade head
+```
+
+Per modifiche minori è possibile eliminare `db.sqlite3` e lasciare che le
+tabelle vengano ricreate automaticamente all'avvio dell'applicazione.
+
 ---
 
 ## ▶️ Running DocCropper

--- a/app/auth/database.py
+++ b/app/auth/database.py
@@ -7,6 +7,12 @@ engine = create_async_engine(DATABASE_URL, echo=False)
 async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 Base = declarative_base()
 
+
+async def init_db() -> None:
+    """Initialize database by creating all tables."""
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
 async def get_user_db():
     from fastapi_users.db import SQLAlchemyUserDatabase
     from app.auth.models import User

--- a/main.py
+++ b/main.py
@@ -651,10 +651,9 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    from app.auth.database import engine, Base, async_session_maker
+    from app.auth.database import init_db, async_session_maker
     from fastapi_users.db import SQLAlchemyUserDatabase
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+    await init_db()
 
     # Create default admin user if none exists
     admin_email = os.getenv("DOCROPPER_ADMIN_EMAIL", "admin@example.com")


### PR DESCRIPTION
## Summary
- add `init_db` helper to create auth tables
- invoke `init_db` at application startup
- document SQLite database backup and migration procedures

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'uvicorn')*
- `pip install fastapi uvicorn` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b18525c0008326af7de062c95e64c2