### PR TITLE
Add FastAPI license server service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,6 @@ redis
 python-dotenv
 bcrypt==4.1.2
 setproctitle
+
+alembic
+psycopg2-binary

--- a/services/license_server/alembic.ini
+++ b/services/license_server/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+sqlalchemy.url = postgresql+psycopg2://user:password@localhost/licenses
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname = 
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/services/license_server/crud.py
+++ b/services/license_server/crud.py
@@ -1,0 +1,24 @@
+import uuid
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+def create_license(db: Session, license_in: schemas.LicenseCreate) -> models.License:
+    license_key = uuid.uuid4().hex
+    db_license = models.License(
+        key=license_key,
+        license_type=license_in.license_type,
+        expires_at=license_in.expires_at,
+        allowed_domains=license_in.allowed_domains,
+        plugins=license_in.plugins,
+        settings=license_in.settings,
+    )
+    db.add(db_license)
+    db.commit()
+    db.refresh(db_license)
+    return db_license
+
+
+def get_license(db: Session, key: str) -> models.License | None:
+    return db.query(models.License).filter(models.License.key == key).first()

--- a/services/license_server/database.py
+++ b/services/license_server/database.py
@@ -1,0 +1,18 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+psycopg2://user:password@localhost/licenses")
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/services/license_server/main.py
+++ b/services/license_server/main.py
@@ -1,0 +1,20 @@
+from fastapi import Depends, FastAPI
+from sqlalchemy.orm import Session
+
+from . import crud, schemas, models
+from .database import engine, get_db
+
+models.Base.metadata.create_all(bind=engine)
+
+app = FastAPI(title="License Server")
+
+
+@app.post("/licenses", response_model=schemas.LicenseResponse)
+def issue_license(license_in: schemas.LicenseCreate, db: Session = Depends(get_db)):
+    return crud.create_license(db, license_in)
+
+
+@app.get("/verify", response_model=schemas.LicenseVerifyResponse)
+def verify_license(email: str, license: str, token: str, db: Session = Depends(get_db)):
+    db_license = crud.get_license(db, license)
+    return schemas.LicenseVerifyResponse(valid=db_license is not None, license=db_license)

--- a/services/license_server/migrations/env.py
+++ b/services/license_server/migrations/env.py
@@ -1,0 +1,44 @@
+import sys
+import os
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..")))
+
+from license_server import models  # noqa
+from license_server.database import Base  # noqa
+
+config = context.config
+fileConfig(config.config_file_name)
+target_metadata = Base.metadata
+
+
+def run_migrations_offline():
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/services/license_server/migrations/versions/0001_create_license_table.py
+++ b/services/license_server/migrations/versions/0001_create_license_table.py
@@ -1,0 +1,28 @@
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '0001'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    license_type_enum = sa.Enum('free', 'demo', 'demo_full', 'developer', 'pro', name='licensetype')
+    license_type_enum.create(op.get_bind())
+    op.create_table(
+        'licenses',
+        sa.Column('key', sa.String(), nullable=False),
+        sa.Column('license_type', sa.Enum('free', 'demo', 'demo_full', 'developer', 'pro', name='licensetype'), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.Column('allowed_domains', postgresql.ARRAY(sa.String())),
+        sa.Column('plugins', postgresql.JSON()),
+        sa.Column('settings', postgresql.JSON()),
+        sa.PrimaryKeyConstraint('key')
+    )
+
+
+def downgrade():
+    op.drop_table('licenses')
+    sa.Enum(name='licensetype').drop(op.get_bind())

--- a/services/license_server/models.py
+++ b/services/license_server/models.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, String, DateTime, Enum, JSON
+from sqlalchemy.dialects.postgresql import ARRAY
+import enum
+
+from .database import Base
+
+
+class LicenseType(str, enum.Enum):
+    free = "free"
+    demo = "demo"
+    demo_full = "demo_full"
+    developer = "developer"
+    pro = "pro"
+
+
+class License(Base):
+    __tablename__ = "licenses"
+
+    key = Column(String, primary_key=True, index=True)
+    license_type = Column(Enum(LicenseType), nullable=False)
+    expires_at = Column(DateTime, nullable=True)
+    allowed_domains = Column(ARRAY(String))
+    plugins = Column(JSON)
+    settings = Column(JSON)

--- a/services/license_server/schemas.py
+++ b/services/license_server/schemas.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List, Optional, Dict, Any
+
+from pydantic import BaseModel, EmailStr
+
+from .models import LicenseType
+
+
+class LicenseBase(BaseModel):
+    key: str
+    license_type: LicenseType
+    expires_at: Optional[datetime]
+    allowed_domains: List[str] = []
+    plugins: Optional[Dict[str, Any]] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class LicenseCreate(BaseModel):
+    email: EmailStr
+    license_type: LicenseType
+    expires_at: Optional[datetime] = None
+    allowed_domains: List[str] = []
+    plugins: Optional[Dict[str, Any]] = None
+    settings: Optional[Dict[str, Any]] = None
+
+
+class LicenseResponse(LicenseBase):
+    class Config:
+        orm_mode = True
+
+
+class LicenseVerifyResponse(BaseModel):
+    valid: bool
+    license: Optional[LicenseResponse]


### PR DESCRIPTION
## Summary
- add FastAPI license server with License model and endpoints
- include Alembic migrations and PostgreSQL configuration
- update dependencies for database support

## Testing
- `pytest`
- `pip install alembic` *(fails: Could not find a version that satisfies the requirement alembic)*
- `pip install fastapi` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_68b89194dadc8326b12c2cab4e7a30ba