### PR TITLE
Extend license verification with types and features

### DIFF
--- a/app/licensing/check.py
+++ b/app/licensing/check.py
@@ -4,11 +4,13 @@ import os
 
 
 async def verify_license(email: str, license_type: str, token: str) -> dict:
-    """Check the remote Fabrik table and return the parsed response.
+    """Check the remote license server and return the parsed response.
 
     The returned object always contains at least ``{"valid": bool}`` and may
-    include a ``plugins`` map of optional components or a ``settings`` object
-    with configuration values that should override the local ones.
+    include optional metadata such as ``license_type`` and a list of
+    ``features``.  Older servers may still return a ``plugins`` map or a
+    ``settings`` object with configuration values that should override the
+    local ones.
     """
 
     license_url = os.getenv("LICENSE_CHECK_URL")

--- a/services/api/app.py
+++ b/services/api/app.py
@@ -804,8 +804,27 @@ async def require_valid_license(
     if not data.get("valid", False):
         raise HTTPException(status_code=403, detail="Licenza non valida")
 
+    license_type = data.get("license_type")
+    if license_type in {"developer", "demo_full"}:
+        save_settings({"license_type": license_type})
+    else:
+        # Fall back to a minimal demo mode when no license information is
+        # provided or when the license corresponds to the free tier.
+        save_settings({"license_type": "demo_base"})
+
+    features = data.get("features")
     plugins = data.get("plugins", {})
-    if isinstance(plugins, dict) and plugins:
+    if isinstance(features, list):
+        settings = load_settings()
+        updates = {}
+        if license_type in {"developer", "demo_full"}:
+            for name in features:
+                key = f"enable_{name}"
+                if not settings.get(key, False):
+                    updates[key] = True
+        if updates:
+            save_settings(updates)
+    elif isinstance(plugins, dict) and plugins:
         settings = load_settings()
         updates = {}
         for name, allowed in plugins.items():

--- a/static/admin.html
+++ b/static/admin.html
@@ -41,6 +41,23 @@
             <button type="submit">Create</button>
         </form>
     </section>
+    <section id="licenseSection">
+        <h2>Licenses</h2>
+        <table id="licenseTable">
+            <thead><tr><th>ID</th><th>Type</th><th>Domains</th><th>Actions</th></tr></thead>
+            <tbody></tbody>
+        </table>
+        <h3>Create License</h3>
+        <form id="createLicenseForm">
+            <input type="text" id="licenseCustomer" placeholder="customer" required>
+            <select id="licenseType">
+                <option value="demo_full">Demo Full</option>
+                <option value="developer">Developer</option>
+            </select>
+            <input type="text" id="licenseDomains" placeholder="allowed domains (comma separated)">
+            <button type="submit">Create</button>
+        </form>
+    </section>
 <script src="/static/admin.js"></script>
 </body>
 </html>

--- a/static/admin.js
+++ b/static/admin.js
@@ -62,8 +62,44 @@ async function createUser(event) {
     }
 }
 
+async function loadLicenses() {
+    const res = await fetch('/licenses');
+    if (!res.ok) return;
+    const list = await res.json();
+    const tbody = document.querySelector('#licenseTable tbody');
+    tbody.innerHTML = '';
+    list.forEach(l => {
+        const tr = document.createElement('tr');
+        const domains = (l.allowed_domains || []).join(', ');
+        tr.innerHTML = `<td>${l.id}</td><td>${l.license_type}</td><td>${domains}</td>` +
+            `<td><button data-id="${l.id}">Delete</button></td>`;
+        tbody.appendChild(tr);
+    });
+    tbody.querySelectorAll('button').forEach(btn => btn.addEventListener('click', async () => {
+        await fetch('/licenses/' + btn.dataset.id, {method: 'DELETE'});
+        loadLicenses();
+    }));
+}
+
+async function createLicense(event) {
+    event.preventDefault();
+    const customer = document.getElementById('licenseCustomer').value;
+    const license_type = document.getElementById('licenseType').value;
+    const domains = document.getElementById('licenseDomains').value.split(',').map(d => d.trim()).filter(Boolean);
+    const payload = {customer, product: 'DocCropper', license_type, allowed_domains: domains};
+    await fetch('/licenses', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    });
+    loadLicenses();
+    document.getElementById('createLicenseForm').reset();
+}
+
 document.getElementById('settingsForm').addEventListener('submit', saveSettings);
 document.getElementById('createUserForm').addEventListener('submit', createUser);
+document.getElementById('createLicenseForm').addEventListener('submit', createLicense);
 
 loadSettings();
 loadUsers();
+loadLicenses();

--- a/static/app.js
+++ b/static/app.js
@@ -721,7 +721,7 @@ function applySettings(cfg) {
     demoFullMode = !!cfg.demo_full_mode;
     const devLicense = ((cfg.license_key || '').toUpperCase().endsWith('-DEV')) ||
         (cfg.license_level && cfg.license_level.toLowerCase() === 'developer') ||
-        (cfg.license_type && cfg.license_type.toLowerCase() === 'developer');
+        (cfg.license_type && ['developer', 'demo_full'].includes(cfg.license_type.toLowerCase()));
     if (devSettingsBtn) {
         devSettingsBtn.style.display = devLicense ? 'inline-block' : 'none';
     }
@@ -3496,7 +3496,7 @@ function renderLogin(cfg) {
     }
     const devLicense = (cfg.license_key || '').toUpperCase().endsWith('-DEV') ||
         (cfg.license_level && cfg.license_level.toLowerCase() === 'developer') ||
-        (cfg.license_type && cfg.license_type.toLowerCase() === 'developer');
+        (cfg.license_type && ['developer', 'demo_full'].includes(cfg.license_type.toLowerCase()));
     if (cfg.login_dev_only && !devLicense) {
         loginArea.style.display = 'none';
         return;

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -1,5 +1,5 @@
 import os
-from typing import List, Dict
+from typing import List, Dict, Optional
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
@@ -10,7 +10,17 @@ app = FastAPI(title="DocCropper Simple Webapp")
 security = HTTPBasic()
 
 # in-memory store for licenses
-LICENSES: Dict[str, Dict] = {}
+LICENSES: Dict[str, Dict] = {
+    # Pre-populated demo license limited to a test domain
+    "demo-full": {
+        "id": "demo-full",
+        "customer": "Demo User",
+        "product": "DocCropper",
+        "license_type": "demo_full",
+        "allowed_domains": ["test.example.com"],
+        "feature_flags": {},
+    }
+}
 
 
 def get_current_user(credentials: HTTPBasicCredentials = Depends(security)):
@@ -29,12 +39,16 @@ class License(BaseModel):
     id: str
     customer: str
     product: str
+    license_type: str = "free"
+    allowed_domains: List[str] = []
     feature_flags: Dict[str, bool] = {}
 
 
 class LicenseCreate(BaseModel):
     customer: str
     product: str
+    license_type: str = "free"
+    allowed_domains: Optional[List[str]] = None
     feature_flags: Dict[str, bool] = {}
 
 
@@ -46,7 +60,10 @@ def list_licenses(user: str = Depends(get_current_user)):
 @app.post("/licenses", response_model=License, status_code=status.HTTP_201_CREATED)
 def create_license(data: LicenseCreate, user: str = Depends(get_current_user)):
     license_id = str(uuid4())
-    lic = License(id=license_id, **data.dict())
+    payload = data.dict()
+    if payload.get("allowed_domains") is None:
+        payload["allowed_domains"] = []
+    lic = License(id=license_id, **payload)
     LICENSES[license_id] = lic.dict()
     return lic
 
@@ -57,4 +74,28 @@ def get_license(license_id: str, user: str = Depends(get_current_user)):
     if not lic:
         raise HTTPException(status_code=404, detail="License not found")
     return lic
+
+
+@app.delete("/licenses/{license_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_license(license_id: str, user: str = Depends(get_current_user)):
+    if license_id in LICENSES:
+        del LICENSES[license_id]
+    return None
+
+
+@app.get("/verify")
+def verify_license_endpoint(license_id: str, domain: Optional[str] = None):
+    """Simple verification endpoint returning license info."""
+    lic = LICENSES.get(license_id)
+    if not lic:
+        return {"valid": False}
+    domains = lic.get("allowed_domains") or []
+    if domain and domains and domain not in domains:
+        return {"valid": False}
+    features = [name for name, ok in lic.get("feature_flags", {}).items() if ok]
+    return {
+        "valid": True,
+        "license_type": lic.get("license_type", "free"),
+        "features": features,
+    }
 


### PR DESCRIPTION
## Summary
- Expand license verification to include `license_type` and feature flags
- Gate plugins and menus on developer or demo_full licenses, falling back to demo base otherwise
- Add admin tools and demo license management with domain restrictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8928630b883268474f3bd92aeeb5a