### PR TITLE
Document license API and activation flows

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -1,0 +1,12 @@
+# API Documentation
+
+## Flussi di attivazione
+- La chiave di licenza può essere specificata in `env/license.env`, in un file `.env` alla radice o in `settings.json`. La chiave definisce l'edizione attiva e può innescare convalide manuali oppure online in base al prefisso utilizzato.
+- Le edizioni Pro e Full possono funzionare offline dopo l'attivazione; è richiesta la connessione solo per attivare o rinnovare la licenza e per le licenze sponsorizzate che recuperano i contenuti da Internet.
+
+## Tipologie di licenza
+- **Free** – watermark applicato e massimo cinque immagini per progetto.
+- **Pro** – nessun watermark e immagini illimitate; un plugin LAN può limitare gli utenti di rete a blocchi di cinque.
+- **Full** – tutte le funzionalità abilitate inclusi i plugin opzionali e l'accesso LAN illimitato.
+- **Demo Full** – modalità nascosta con tutte le funzionalità ma con watermark e avvisi di demo.
+- **Developer** – l'uso della chiave definita da `DOCROPPER_DEV_LICENSE` abilita funzionalità e plugin di sviluppo.

--- a/webapp/main.py
+++ b/webapp/main.py
@@ -5,7 +5,12 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel
 from uuid import uuid4
 
-app = FastAPI(title="DocCropper Simple Webapp")
+app = FastAPI(
+    title="DocCropper Simple Webapp",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
+)
 
 security = HTTPBasic()
 
@@ -38,12 +43,26 @@ class LicenseCreate(BaseModel):
     feature_flags: Dict[str, bool] = {}
 
 
-@app.get("/licenses", response_model=List[License])
+@app.get(
+    "/licenses",
+    response_model=List[License],
+    summary="Elenco delle licenze disponibili",
+    responses={200: {"description": "Lista delle licenze"}, 401: {"description": "Credenziali non valide"}},
+)
 def list_licenses(user: str = Depends(get_current_user)):
     return list(LICENSES.values())
 
 
-@app.post("/licenses", response_model=License, status_code=status.HTTP_201_CREATED)
+@app.post(
+    "/licenses",
+    response_model=License,
+    status_code=status.HTTP_201_CREATED,
+    summary="Crea una nuova licenza",
+    responses={
+        201: {"description": "Licenza creata"},
+        401: {"description": "Credenziali non valide"},
+    },
+)
 def create_license(data: LicenseCreate, user: str = Depends(get_current_user)):
     license_id = str(uuid4())
     lic = License(id=license_id, **data.dict())
@@ -51,7 +70,16 @@ def create_license(data: LicenseCreate, user: str = Depends(get_current_user)):
     return lic
 
 
-@app.get("/licenses/{license_id}", response_model=License)
+@app.get(
+    "/licenses/{license_id}",
+    response_model=License,
+    summary="Recupera una licenza esistente",
+    responses={
+        200: {"description": "Licenza trovata"},
+        401: {"description": "Credenziali non valide"},
+        404: {"description": "Licenza non trovata"},
+    },
+)
 def get_license(license_id: str, user: str = Depends(get_current_user)):
     lic = LICENSES.get(license_id)
     if not lic:


### PR DESCRIPTION
## Summary
- expose OpenAPI docs for license microservice at `/docs` and `/redoc`
- document license endpoints with summaries and response metadata
- add `API_DOCS.md` outlining activation flows and available license types

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b89a4c0f1c8326b59c0be92ca4ae78