### PR TITLE
Add max_sessions to auth and session enforcement

### DIFF
--- a/app/auth/models.py
+++ b/app/auth/models.py
@@ -7,3 +7,4 @@ class User(SQLAlchemyBaseUserTable[int], Base):
     id = Column(Integer, primary_key=True, index=True)
     license_type = Column(String(length=10), default="free")
     license_token = Column(String(length=64), nullable=True)
+    max_sessions = Column(Integer, nullable=True)

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter, Depends
 from fastapi_users import FastAPIUsers
-from fastapi_users.authentication import JWTStrategy, AuthenticationBackend, CookieTransport
+from fastapi_users.authentication import (
+    JWTStrategy,
+    AuthenticationBackend,
+    CookieTransport,
+)
+from fastapi_users.jwt import generate_jwt
 from app.auth.models import User
 from app.auth.user_manager import UserManager
 from app.auth.database import get_user_db
@@ -9,8 +14,27 @@ import os
 
 cookie_transport = CookieTransport(cookie_name="auth", cookie_max_age=3600)
 
+
+class CustomJWTStrategy(JWTStrategy):
+    async def write_token(self, user):  # type: ignore[override]
+        data = {"sub": str(user.id)}
+        if self.token_audience is not None:
+            data["aud"] = self.token_audience
+        max_sessions = getattr(user, "max_sessions", None)
+        if max_sessions is not None:
+            data["max_sessions"] = max_sessions
+        email = getattr(user, "email", None)
+        if email is not None:
+            data["email"] = email
+        return generate_jwt(
+            data,
+            self.lifetime_seconds,
+            self.secret,
+            self.algorithm,
+        )
+
 def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(secret=os.getenv("SECRET_KEY"), lifetime_seconds=3600)
+    return CustomJWTStrategy(secret=os.getenv("SECRET_KEY"), lifetime_seconds=3600)
 
 auth_backend = AuthenticationBackend(
     name="jwt",

--- a/app/auth/schemas.py
+++ b/app/auth/schemas.py
@@ -4,11 +4,14 @@ from typing import Optional
 class UserRead(schemas.BaseUser[int]):
     license_type: str
     license_token: Optional[str] = None
+    max_sessions: Optional[int] = None
 
 class UserCreate(schemas.BaseUserCreate):
     license_type: str = "free"
     license_token: Optional[str] = None
+    max_sessions: Optional[int] = None
 
 class UserUpdate(schemas.BaseUserUpdate):
     license_type: Optional[str] = None
     license_token: Optional[str] = None
+    max_sessions: Optional[int] = None

--- a/auth_server.js
+++ b/auth_server.js
@@ -3,9 +3,12 @@ const session = require('express-session');
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 const path = require('path');
+const jwt = require('jsonwebtoken');
 require('dotenv').config();
 
 const app = express();
+
+app.use(express.json());
 
 app.use(session({
   secret: 'doccropper-secret',
@@ -52,6 +55,19 @@ app.get('/logout', (req, res, next) => {
       res.redirect('/');
     });
   });
+});
+
+app.post('/verify-token', (req, res) => {
+  const { token } = req.body || {};
+  if (!token) {
+    return res.status(400).json({ valid: false, message: 'Token required' });
+  }
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET_KEY);
+    res.json({ valid: true, max_sessions: decoded.max_sessions });
+  } catch (err) {
+    res.status(401).json({ valid: false, message: 'Invalid token' });
+  }
 });
 
 app.use(express.static(path.join(__dirname, 'static')));

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "express": "^4.18.2",
     "express-session": "^1.17.3",
     "passport": "^0.6.0",
-    "passport-google-oauth20": "^2.0.0"
+    "passport-google-oauth20": "^2.0.0",
+    "jsonwebtoken": "^9.0.0"
   }
 }

--- a/services/api/app.py
+++ b/services/api/app.py
@@ -192,6 +192,18 @@ MAX_UPLOAD_BYTES = MAX_UPLOAD_MB * 1024 * 1024
 
 BASE_DIR = Path(__file__).resolve().parent
 
+
+def active_session_count() -> int:
+    """Return the number of active session directories."""
+    if not os.path.isdir(SESSIONS_ROOT):
+        return 0
+    total = 0
+    for name in os.listdir(SESSIONS_ROOT):
+        path = os.path.join(SESSIONS_ROOT, name)
+        if os.path.isdir(path):
+            total += 1
+    return total
+
 def repo_has_updates() -> bool:
     """Check if remote Git repository has new commits."""
     try:
@@ -963,8 +975,11 @@ async def favicon():
     icon_path = os.path.join(os.path.dirname(__file__), 'static', 'logos', 'app_logo.png')
     return FileResponse(icon_path, headers={"Cache-Control": "no-cache"})
 
-def make_index_response(request: Request, lang: str) -> HTMLResponse:
+def make_index_response(request: Request, lang: str, user: User | None = None) -> HTMLResponse:
     cleanup_old_sessions()
+    if user and user.max_sessions:
+        if active_session_count() >= user.max_sessions:
+            raise HTTPException(status_code=403, detail="Session limit exceeded")
     session_id = request.cookies.get("session_id")
     if not session_id:
         session_id = uuid.uuid4().hex
@@ -1011,14 +1026,14 @@ def make_index_response(request: Request, lang: str) -> HTMLResponse:
 
 
 @app.get("/", response_class=HTMLResponse)
-async def read_root(request: Request):
+async def read_root(request: Request, user: User | None = Depends(fastapi_users.current_user(optional=True))):
     lang = load_settings().get("language", "it")
-    return make_index_response(request, lang)
+    return make_index_response(request, lang, user)
 
 
 @app.get("/{lang:en|it}", response_class=HTMLResponse)
-async def read_root_lang(lang: str, request: Request):
-    return make_index_response(request, lang)
+async def read_root_lang(lang: str, request: Request, user: User | None = Depends(fastapi_users.current_user(optional=True))):
+    return make_index_response(request, lang, user)
 
 
 async def require_superuser(user: User = Depends(fastapi_users.current_user())):


### PR DESCRIPTION
## Summary
- track `max_sessions` on users and expose it in JWT tokens
- validate token sessions in the Node auth server and return `max_sessions`
- enforce configured session limit server-side

## Testing
- `npm test` (fails: Missing script: "test")
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9afceb6d883268df5da2806bbb2d1